### PR TITLE
Call one SOAP endpoint for all requests save end-user username/password validation

### DIFF
--- a/lib/cdx/client.rb
+++ b/lib/cdx/client.rb
@@ -8,7 +8,7 @@ module CDX
 
     def default_opts
       {
-        :wsdl => "https://devngn.epacdxnode.net/cdx-register/services/RegisterAuthService?wsdl",
+        :wsdl => "https://devngn.epacdxnode.net/cdx-register/services/RegisterSignService?wsdl",
         :pretty_print_xml => true,
         :log => true,
         :soap_version => 2,
@@ -25,7 +25,8 @@ module CDX
 
     def self.auth
       new({
-        :filters => [:password]
+        :filters => [:password],
+        :wsdl => "https://devngn.epacdxnode.net/cdx-register/services/RegisterAuthService?wsdl"
       })
     end
 

--- a/spec/cdx_spec.rb
+++ b/spec/cdx_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe CDX do
     end
 
     it 'signing client should have default keys' do
-      expect(signin_client.savon.globals[:wsdl]).to_not be_nil
+      expect(signin_client.savon.globals[:wsdl]).to eq("https://devngn.epacdxnode.net/cdx-register/services/RegisterSignService?wsdl")
       expect(signin_client.savon.globals[:pretty_print_xml]).to_not be_nil
       expect(signin_client.savon.globals[:log]).to_not be_nil
       expect(signin_client.savon.globals[:soap_version]).to_not be_nil
@@ -32,7 +32,7 @@ RSpec.describe CDX do
     end
 
     it 'auth client should have default keys' do
-      expect(auth_client.savon.globals[:wsdl]).to_not be_nil
+      expect(auth_client.savon.globals[:wsdl]).to eq("https://devngn.epacdxnode.net/cdx-register/services/RegisterAuthService?wsdl")
       expect(auth_client.savon.globals[:pretty_print_xml]).to_not be_nil
       expect(auth_client.savon.globals[:log]).to_not be_nil
       expect(auth_client.savon.globals[:soap_version]).to_not be_nil


### PR DESCRIPTION
We use the RegisterSignService endpoint for all service calls other than
authenticating the end user by username/password. Even the "system" user
authentication is with RegisterSignService.

Change the default endpoint URI to RegisterSignService and override the
user authentication endpoint to RegisterAuthService.
