### PR TITLE
Sign or upload to match comps

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@
 - To build and serve the app, run `rake serve`.
 - To deploy to 18F's cloud, run `rake deploy`.
 - To add dummy data for developing against, run `rake populate:manifests`.
-- To (re)build the Elasticsearch index, run `rake search:index`.
+- To (re)build the Elasticsearch index, run `rake search:index FORCE=y`.
 
 To add analytics support needed for production, prepend `JEKYLL_ENV=production` to any of the above commands.
 

--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ gem 'elasticsearch-rails-ha', git: 'https://github.com/18F/elasticsearch-rails-h
 group :development, :test do
   gem 'rack-test', require: 'rack/test'
   gem 'rspec'
+  gem 'rspec-mocks', '3.4.0'
 end
 
 group :test do

--- a/_static/assets/js/app.js
+++ b/_static/assets/js/app.js
@@ -80,8 +80,8 @@
              if (status === "201") {
                console.log("manifest created and located here: " + manifestUri);
              }
-        window.location.href = '/web/sign.html#!/?id=' + emanifestId + '&manifestTrackingNumber=' + self.data.generator.manifest_tracking_number;
-      });
+             window.location.href = '/web/sign-or-upload.html#!/?id=' + emanifestId + '&manifestTrackingNumber=' + self.data.generator.manifest_tracking_number;
+           });
     };
 
     $scope.formatCanonicalPhone = function(isValid, phoneNumber) {
@@ -184,6 +184,32 @@
 
   }]);
 
+  app.controller('SignOrUploadController', function($scope, $location) {
+    var search = $location.search();
+    $scope.data = {};
+
+    Object.keys(search).map(function(k) {
+      $scope.data[k] = search[k];
+    });
+
+    function searchQueryString (data) {
+      var keys = Object.keys(data);
+      var s = keys.map(function(k) {
+        return [k, data[k]].join('=');
+      }).join('&');
+
+      return s;
+    }
+
+    $scope.sign = function () {
+      window.location.href = '/web/sign.html?' + searchQueryString($scope.data);
+    };
+
+    $scope.upload = function () {
+      window.location.href = '/web/bulk-upload.html?' + searchQueryString($scope.data);
+    };
+
+  });
 
   app.controller('SearchController', function($scope, $http) {
     var self = $scope.search = {};
@@ -244,35 +270,35 @@
     }
   });
 
-    app.controller('ManifestDetailController', ['$scope','$http',function($scope, $http) {
+  app.controller('ManifestDetailController', ['$scope','$http',function($scope, $http) {
 
-        function getQueryParams(qs) {
-            qs = qs.split('+').join(' ');
+      function getQueryParams(qs) {
+          qs = qs.split('+').join(' ');
 
-            var params = {},
-                tokens,
-                re = /[?&]?([^=]+)=([^&]*)/g;
+          var params = {},
+              tokens,
+              re = /[?&]?([^=]+)=([^&]*)/g;
 
-            while (tokens = re.exec(qs)) {
-                params[decodeURIComponent(tokens[1])] = decodeURIComponent(tokens[2]);
-            }
+          while (tokens = re.exec(qs)) {
+              params[decodeURIComponent(tokens[1])] = decodeURIComponent(tokens[2]);
+          }
 
-            return params;
-        }
+          return params;
+      }
 
-        var id = getQueryParams(document.location.search).id;;
-        $http.get('/api/0.1/manifest/id/'+id).success(
-            function(response) {
-                //fix for my local env.
-                if(typeof response.content == "string")
-                {
-                    response.content = response.content.replace(/[=]/g, ":");
-                    response.content = response.content.replace(/[>]/g, "");
-                    response.content = jQuery.parseJSON(response.content);
-                }
-              $scope.data = response;
-            });
-    }]);
+      var id = getQueryParams(document.location.search).id;;
+      $http.get('/api/0.1/manifest/id/'+id).success(
+          function(response) {
+              //fix for my local env.
+              if(typeof response.content == "string")
+              {
+                  response.content = response.content.replace(/[=]/g, ":");
+                  response.content = response.content.replace(/[>]/g, "");
+                  response.content = jQuery.parseJSON(response.content);
+              }
+            $scope.data = response;
+          });
+  }]);
 
   app.controller('SignController', function($scope, $http, $location) {
     $scope.state = 'login';

--- a/_static/web/bulk-upload.html
+++ b/_static/web/bulk-upload.html
@@ -6,4 +6,4 @@ layout: template/web
 
 <input class="usa-input-focus" type="file" />
 <br>
-<button class="usa-button-big" type="button" onclick="window.location.href='/web/bulk-upload-success.html'">continue</button>
+<button class="usa-button-big" type="button" onclick="window.location.href='/web/bulk-upload-success.html'">Continue</button>

--- a/_static/web/sign-login.html
+++ b/_static/web/sign-login.html
@@ -1,13 +1,13 @@
-<div class="main-content" id="main-content" sytle="width: none;">
-  <div class="styleguide-content usa-content">
+<div class="main-content" id="main-content">
+  <div class="usa-content">
     <div class="usa-grid-full">
       <div class="preview usa-width-one-half">
         <fieldset>
-          <legend>Log in to sign this manifest</legend>
+          <h2>Log in to sign this manifest</h2>
           <form>
             <label for="user_id">Username</label>
             <input id="user_id" name="user_id" type="text">
-            
+
             <label for="password">Password</label>
             <input id="password" name="passsword" type="password">
             <button class="usa-button-big" type="button" ng-click="authenticate()">Login</button>

--- a/_static/web/sign-or-upload.html
+++ b/_static/web/sign-or-upload.html
@@ -1,0 +1,10 @@
+---
+title: e-Manifest Signing | US EPA
+layout: template/web
+---
+<div id="sign-or-upload-controller" ng-controller="SignOrUploadController">
+  <h2 class="usa-heading subheading">Sign or Upload</h2>
+  <p>Would you like to electronically sign this manifest (CDX login required) or would you like to upload a scan of the original manifest?</p>
+  <button class="usa-button-big" type="button" ng-click="sign()">Sign</button>
+  <button class="usa-button-outline usa-button-big" type="button" ng-click="upload()">Upload</button>
+</div>


### PR DESCRIPTION
According to the [design comps](https://gsa.invisionapp.com/share/4Z4X4ALYB#/screens/115178939), the user should either sign the manifest or upload a scanned version of the manifest.

This PR makes the views capable of this sort of user flow, though currently there is no validation. That is to say that the user could just as easily not submit a scanned version with this version of the PR.

However, this sets up the UI so that the flow is consistent with the design comps.
