### PR TITLE
add redis config for cloud.gov

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web: bundle exec rackup
-worker: bundle exec sidekiq -C config/sidekiq.yml -r ./lib/app.rb
+#worker: bundle exec sidekiq -C config/sidekiq.yml -r ./lib/app.rb

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: bundle exec rackup
+web: bundle exec rackup -p $PORT
 #worker: bundle exec sidekiq -C config/sidekiq.yml -r ./lib/app.rb

--- a/Rakefile
+++ b/Rakefile
@@ -17,7 +17,7 @@ end
 desc 'Build jekyll and serve the sinatra app'
 task :serve do
   Rake::Task['build'].invoke
-  system 'foreman start -p 9292'
+  system 'PORT=9292 script/start'
 end
 
 desc 'Deceptive name: just runs Sinatra without building Jekyll'

--- a/config/redis.rb
+++ b/config/redis.rb
@@ -1,0 +1,15 @@
+# Redis is the storage for Sidekiq
+# we assume defaults are localhost for test/development
+# https://github.com/mperham/sidekiq/wiki/Using-Redis
+if ENV["RACK_ENV"] == "production"
+  vcap = ENV["VCAP_SERVICES"]
+  vcap_config = JSON.parse(vcap)
+  vcap_config.keys.each do |vcap_key|
+    if vcap_key.match(/redis\d+-swarm/)
+      redis_config = vcap_config[vcap_key][0]['credentials']
+      redis_url = "redis://#{redis_config['hostname']}:#{redis_config['port']}"
+      ENV['REDIS_PROVIDER'] ||= redis_url
+      ENV['REDIS_URL']      ||= redis_url
+    end 
+  end
+end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -3,7 +3,6 @@
 #   sidekiq -C config.yml
 ---
 :verbose: false
-:pidfile: ./tmp/pids/sidekiq.pid
 :concurrency: 5
 :timeout: 8
 :queues:

--- a/lib/app.rb
+++ b/lib/app.rb
@@ -2,6 +2,7 @@ require_relative 'app_manifest'
 
 class App < Sinatra::Base
   configure do
+    set :port, (ENV['PORT'] || '9292')
     set :logging, true
     if url = ENV['DATABASE_URL']
       ConnectAR.new(url)

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,4 +1,8 @@
 ---
+
+# general configuration
+command: script/start
+
 applications:
 - name: e-manifest
   memory: 128M

--- a/manifest.yml
+++ b/manifest.yml
@@ -5,3 +5,5 @@ applications:
   domain: 18f.gov
   services:
   - e-manifest-dev-db
+  - emanifest-es-prod
+  - emanifest-redis-prod

--- a/manifest.yml
+++ b/manifest.yml
@@ -7,3 +7,5 @@ applications:
   - e-manifest-dev-db
   - emanifest-es-prod
   - emanifest-redis-prod
+  env:
+    RACK_ENV: production

--- a/script/start
+++ b/script/start
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -e
+set -x
+
+# make sure our pids dir exists
+mkdir -p tmp/pids
+
+# default the port, for development
+# http://stackoverflow.com/a/6859838/358804
+PORT=${PORT-3000}
+
+foreman start -p $PORT


### PR DESCRIPTION
Story: https://trello.com/c/Xdj2N7wd

What I don't know is whether the load order of `config/redis.rb` will set the env before or after Sidekiq gets configured. This may take some try-and-see efforts at cloud.gov.
