### PR TITLE
Create tmp/pids in the bin/setup script

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -31,6 +31,9 @@ if ! command -v foreman > /dev/null; then
   printf 'See https://github.com/ddollar/foreman for install instructions.\n'
 fi
 
+# create directory needed to store the sidekiq.pid
+mkdir -p tmp/pids
+
 # Only if this isn't CI
 # if [ -z "$CI" ]; then
 # fi


### PR DESCRIPTION
We need the tmp/pids directory to exist to run the app. Either we tell the user to create it or we take care of it here.

One. Less. Step.
