### PR TITLE
Refactor CDX classes

### DIFF
--- a/app/models/cdx/activity.rb
+++ b/app/models/cdx/activity.rb
@@ -1,24 +1,35 @@
 class CDX::Activity < CDX::LoggedRequest
-  alias :create :perform
-
   private
+
+  def request
+    client.call(
+      :create_activity_with_properties,
+      {
+        message: {
+          securityToken: opts[:token],
+          signatureUser: opts[:signature_user],
+          dataflowName: opts[:dataflow_name],
+          properties: request_properties
+        }
+      }
+    )
+  end
 
   def request_properties
     [
-      {:Property => {:Key => "activityDescription", :Value => opts[:activity_description]}},
-      {:Property => {:Key => "roleCode", :Value => opts[:role_code]}}
-    ]
-  end
-
-  def request
-    client.call(:create_activity_with_properties, {
-      message: {
-        :securityToken => opts[:token],
-        :signatureUser => opts[:signature_user],
-        :dataflowName => opts[:dataflow_name],
-        :properties => request_properties
+      {
+        Property: {
+          Key: 'activityDescription',
+          Value: opts[:activity_description]
+        }
+      },
+      {
+        Property: {
+          Key: 'roleCode',
+          Value: opts[:role_code]
+        }
       }
-    })
+    ]
   end
 
   def repackage_response

--- a/app/models/cdx/answer.rb
+++ b/app/models/cdx/answer.rb
@@ -1,18 +1,19 @@
 class CDX::Answer < CDX::LoggedRequest
-  alias :validate :perform
-
   private
 
   def request
-    client.call(:validate_answer, {
-      message: {
-        :securityToken => opts["token"],
-        :activityId => opts["activity_id"],
-        :userId => opts["user_id"],
-        :questionId => opts["question_id"],
-        :answer => opts["answer"]
+    client.call(
+      :validate_answer,
+      {
+        message: {
+          securityToken: opts[:token],
+          activityId: opts[:activity_id],
+          userId: opts[:user_id],
+          questionId: opts[:question_id],
+          answer: opts[:answer]
+        }
       }
-    })
+    )
   end
 
   def repackage_response

--- a/app/models/cdx/authenticator.rb
+++ b/app/models/cdx/authenticator.rb
@@ -21,35 +21,50 @@ class CDX::Authenticator
       activity_id: activity_id,
       question: question,
       token: security_token,
-      user_id: signature_user[:UserId]
+      user_id: signature_user[:user_id]
     }
   end
 
   def activity_id
-    @activity_id ||= CDX::Activity.new({
-      token: security_token,
-      signature_user: signature_user,
-      dataflow_name: "eManifest",
-      activity_description: "development test",
-      role_name: "TSDF",
-      role_code: 112090
-    }, output_stream).create
+    @activity_id ||= CDX::Activity.new(
+      {
+        token: security_token,
+        signature_user: signature_user,
+        dataflow_name: "eManifest",
+        activity_description: "development test",
+        role_name: "TSDF",
+        role_code: 112090
+      },
+      output_stream
+    ).perform
   end
 
   def question
-    @question ||= CDX::Question.new({
-      token: security_token,
-      activity_id: activity_id,
-      user: signature_user
-    }, output_stream).get
-  end
-
-  def security_token
-    @security_token ||= CDX::System.new(output_stream).authenticate
+    @question ||= CDX::Question.new(
+      {
+        token: security_token,
+        activity_id: activity_id,
+        user: signature_user
+      },
+      output_stream
+    ).perform
   end
 
   def signature_user
-    @signature_user ||= CDX::User.new(opts, output_stream).authenticate
+    @signature_user ||= CDX::User.new(opts, output_stream).perform
+  end
+
+  def security_token
+    @security_token ||= CDX::System.new(output_stream).perform
+  end
+
+  def repackage_response
+    {
+      token: security_token,
+      activity_id: activity_id,
+      question: question,
+      user_id: signature_user[:UserId]
+    }
   end
 
   def log_and_repackage_error(error)

--- a/app/models/cdx/client.rb
+++ b/app/models/cdx/client.rb
@@ -1,13 +1,15 @@
 class CDX::Client
   attr_reader :savon
 
+  CDX_BASE_URL = ENV['CDX_BASE_URL'] || "https://devngn.epacdxnode.net"
+
   def initialize(opts={})
     @savon = Savon.client(default_opts.merge(opts))
   end
 
   def default_opts
     {
-      wsdl: "https://devngn.epacdxnode.net/cdx-register/services/RegisterSignService?wsdl",
+      wsdl: "#{CDX_BASE_URL}/cdx-register/services/RegisterSignService?wsdl",
       pretty_print_xml: true,
       log: true,
       soap_version: 2,
@@ -27,7 +29,7 @@ class CDX::Client
   def self.auth
     new({
       filters: [:password],
-      wsdl: "https://devngn.epacdxnode.net/cdx-register/services/RegisterAuthService?wsdl"
+      wsdl: "#{CDX_BASE_URL}/cdx-register/services/RegisterAuthService?wsdl"
     })
   end
 

--- a/app/models/cdx/client.rb
+++ b/app/models/cdx/client.rb
@@ -7,25 +7,27 @@ class CDX::Client
 
   def default_opts
     {
-      :wsdl => "https://devngn.epacdxnode.net/cdx-register/services/RegisterSignService?wsdl",
-      :pretty_print_xml => true,
-      :log => true,
-      :soap_version => 2,
-      :convert_request_keys_to => :none,
+      wsdl: "https://devngn.epacdxnode.net/cdx-register/services/RegisterSignService?wsdl",
+      pretty_print_xml: true,
+      log: true,
+      soap_version: 2,
+      convert_request_keys_to: :none,
     }
   end
 
   def self.signin
-    new({
-      :multipart => true,
-      :filters => [:password, :credential, :answer]
-    })
+    new(
+      {
+        multipart: true,
+        filters: [:password, :credential, :answer]
+      }
+    )
   end
 
   def self.auth
     new({
-      :filters => [:password],
-      :wsdl => "https://devngn.epacdxnode.net/cdx-register/services/RegisterAuthService?wsdl"
+      filters: [:password],
+      wsdl: "https://devngn.epacdxnode.net/cdx-register/services/RegisterAuthService?wsdl"
     })
   end
 

--- a/app/models/cdx/logged_request.rb
+++ b/app/models/cdx/logged_request.rb
@@ -26,7 +26,7 @@ class CDX::LoggedRequest
   end
 
   def response
-    @respose ||= request
+    @response ||= request
   end
 
   def client

--- a/app/models/cdx/manifest.rb
+++ b/app/models/cdx/manifest.rb
@@ -16,13 +16,11 @@ class CDX::Manifest
   private
 
   def repackage_response
-    {
-      document_id: document_id
-    }
+    { document_id: document_id }
   end
 
   def validate_answer
-    CDX::Answer.new(opts, output_stream).validate
+    CDX::Answer.new(opts, output_stream).perform
   end
 
   def document_id

--- a/app/models/cdx/question.rb
+++ b/app/models/cdx/question.rb
@@ -1,16 +1,17 @@
 class CDX::Question < CDX::LoggedRequest
-  alias :get :perform
-
   private
 
   def request
-    client.call(:get_question, {
-      message: {
-        :securityToken => opts[:token],
-        :activityId =>    opts[:activity_id],
-        :userId =>        opts[:user][:UserId]
+    client.call(
+      :get_question,
+      {
+        message: {
+          securityToken: opts[:token],
+          activityId: opts[:activity_id],
+          userId: opts[:user][:UserId]
+        }
       }
-    })
+    )
   end
 
   def question_response_data
@@ -19,8 +20,8 @@ class CDX::Question < CDX::LoggedRequest
 
   def repackage_response
     {
-      :question_id => question_response_data[:question_id],
-      :question_text => question_response_data[:text]
+      question_id: question_response_data[:question_id],
+      question_text: question_response_data[:text]
     }
   end
 end

--- a/app/models/cdx/sign.rb
+++ b/app/models/cdx/sign.rb
@@ -1,19 +1,24 @@
 class CDX::Sign < CDX::LoggedRequest
+  private
+
   def request
-    client.call(:sign, {
-      message: {
-        :securityToken => opts["token"],
-        :activityId => opts["activity_id"],
-        :signatureDocument => signature_document
+    client.call(
+      :sign,
+      {
+        message: {
+          securityToken: opts[:token],
+          activityId: opts[:activity_id],
+          signatureDocument: signature_document
+        }
       }
-    })
+    )
   end
 
   def signature_document
     {
-      :Name => "e-manifest #{opts['id']}",
-      :Format => "BIN",
-      :Content => opts[:manifest_content]
+      Name: "e-manifest #{opts[:id]}",
+      Format: "BIN",
+      Content: opts[:manifest_content]
     }
   end
 

--- a/app/models/cdx/system.rb
+++ b/app/models/cdx/system.rb
@@ -5,8 +5,6 @@ class CDX::System < CDX::LoggedRequest
     @output_stream = output_stream
   end
 
-  alias :authenticate :perform
-
   private
 
   def log_opts
@@ -18,15 +16,15 @@ class CDX::System < CDX::LoggedRequest
     super
   end
 
-  def repackage_response
-    response.body[:authenticate_response][:security_token]
-  end
-
   def response
     @response ||= client.call(
       :authenticate,
       { message: credentials }
     )
+  end
+
+  def repackage_response
+    response.body[:authenticate_response][:security_token]
   end
 
   def credentials

--- a/app/models/cdx/user.rb
+++ b/app/models/cdx/user.rb
@@ -1,14 +1,15 @@
 class CDX::User < CDX::LoggedRequest
-  alias :authenticate :perform
-
   private
 
   def request
-    client.call(:authenticate, {
-      :message => {
-        :userId => opts['user_id'], :password => opts['password']
+    client.call(
+      :authenticate, {
+        message: {
+          userId: opts[:user_id],
+          password: opts[:password]
+        }
       }
-    })
+    )
   end
 
   def client
@@ -27,10 +28,10 @@ class CDX::User < CDX::LoggedRequest
 
   def repackage_response
     {
-      :UserId => user_data[:user_id],
-      :FirstName => user_data[:first_name],
-      :LastName => user_data[:last_name],
-      :MiddleInitial => user_data[:middle_initial]
+      UserId: user_data[:user_id],
+      FirstName: user_data[:first_name],
+      LastName: user_data[:last_name],
+      MiddleInitial: user_data[:middle_initial]
     }
   end
 end

--- a/spec/models/cdx/activity_spec.rb
+++ b/spec/models/cdx/activity_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+describe 'CDX::Activity.new(args, output_stream).perform' do
+  it 'returns the activity_id from the response' do
+    VCR.use_cassette('create_activity_with_properties') do
+      activity_id_from_fixture = "_e88f9df3-ce3e-45bc-91ff-6c6601d85442"
+
+      activity = CDX::Activity.new(args, output_stream).perform
+
+      expect(activity).to eq(activity_id_from_fixture)
+    end
+  end
+
+  private
+
+  def output_stream
+    @_output_stream ||= StringIO.new('')
+  end
+
+  def args
+    {
+      activity_description: 'activity_description',
+      role_code: 'role_code',
+      token: token_from_fixture,
+      signature_user: 'signature_user',
+      dataflow_name: 'dataflow_name'
+    }
+  end
+
+  def token_from_fixture
+    "fakeSecurityToken"
+  end
+end

--- a/spec/models/cdx/authenticator_spec.rb
+++ b/spec/models/cdx/authenticator_spec.rb
@@ -1,0 +1,75 @@
+require 'rails_helper'
+
+describe 'CDX::Authenticator.new(args, output_stream).perform' do
+  it 'returns the repackaged data' do
+    VCR.use_cassette('create_authenticator') do
+      question = {
+        question_id: "1",
+        question_text: "What is the first and middle name of your oldest sibling?"
+      }
+      security_token_from_fixture = 'fakeSecurityToken'
+      activity_id_from_fixture = 'fakeActivityId'
+      user_id_from_fixture = 'fakeUserId'
+      opts = { user_id: 'fakeUserId', password: 'fakePassword' }
+
+      expect(CDX::Authenticator.new(opts, output_stream).perform).to eq({
+        token: security_token_from_fixture,
+        activity_id: activity_id_from_fixture,
+        question: question,
+        user_id: user_id_from_fixture
+      })
+    end
+  end
+
+  describe 'when there is an authentication error' do
+    context "user id does not exist in CDX" do
+      it 'returns the error description' do
+       VCR.use_cassette('create_authenticator_with_wrong_user_id') do
+          opts = { user_id: "wrong", password: "wrong" }
+
+          authenticator = CDX::Authenticator.new(opts, output_stream).perform
+
+          expect(authenticator).to eq(
+            { description: 'user WRONG does not exist' }
+          )
+       end
+      end
+    end
+
+    context "password is incorrect" do
+      it 'returns the error description' do
+        VCR.use_cassette('create_authenticator_with_wrong_password') do
+          opts = { user_id: "real_user_id", password: "wrong" }
+
+          authenticator = CDX::Authenticator.new(opts, output_stream).perform
+
+          expect(authenticator).to eq(
+            { description: 'Unable to authenticate user - The password is invalid.' }
+          )
+        end
+      end
+    end
+  end
+
+  describe 'when there is a register error' do
+    it 'returns the error description' do
+      VCR.use_cassette('create_authenticator_with_register_error') do
+        opts = { user_id: "real_user_id", password: "correct_password" }
+
+        authenticator = CDX::Authenticator.new(opts, output_stream).perform
+
+        expect(authenticator).to eq(
+          {
+            description: 'Unable to authenticate user - The user account could not be located. Could not perform central authentication for user <change_me> in domain <default>'
+          }
+        )
+      end
+    end
+  end
+
+  private
+
+  def output_stream
+    @_output_stream ||= StringIO.new('')
+  end
+end

--- a/spec/models/cdx/system_spec.rb
+++ b/spec/models/cdx/system_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+describe 'CDX::System.new(output_stream).perform' do
+  it 'makes a request for operations and logs to stdout' do
+    VCR.use_cassette('auth_success') do
+      system = CDX::System.new(output_stream)
+
+      system.perform
+
+      expect(system.output_stream.string).to include("authenticate_user")
+    end
+  end
+
+  it 'returns the authentication token' do
+    VCR.use_cassette('auth_success') do
+      security_token_from_fixture = 'fakeSecurityToken'
+
+      system = CDX::System.new(output_stream).perform
+
+      expect(system).to eq(security_token_from_fixture)
+    end
+  end
+end
+

--- a/spec/models/cdx/user_spec.rb
+++ b/spec/models/cdx/user_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+describe '#CDX::User.new(args, output_stream).perform' do
+  it 'should return a re-packaged response' do
+    VCR.use_cassette('auth_success') do
+      first_name_from_fixture = "Brandon"
+      last_name_from_fixture = "Kirby"
+      user_id_from_fixture = "18F_CERTIFIER"
+
+      authenticate_user_call = CDX::User.new(user_input_data, output_stream).perform
+
+      expect(authenticate_user_call).to eq({
+        UserId: user_id_from_fixture,
+        FirstName: first_name_from_fixture,
+        LastName: last_name_from_fixture,
+        MiddleInitial: nil,
+      })
+    end
+  end
+
+  it 'throws some debugging into stdout' do
+    VCR.use_cassette('auth_success') do
+      user = CDX::User.new(user_input_data, output_stream)
+
+      user.perform
+
+      expect(user.output_stream.string).to include(user_input_data.to_s)
+    end
+  end
+
+  private
+
+  def user_input_data
+    { user_id: 'example_user_id', password: 'example_ps'}
+  end
+end

--- a/spec/models/cdx_spec.rb
+++ b/spec/models/cdx_spec.rb
@@ -1,187 +1,6 @@
 require 'rails_helper'
 
 describe "CDX" do
-  let(:output_stream) { StringIO.new('') }
-
-  describe 'available clients' do
-    # NOTE: this is all configuration and shouldn't really be tested ...
-    # but, trying to make sure I keep the code working the same, while
-    # encapsulating it a little!
-
-    let(:signin_client) { CDX::Client.signin }
-    let(:auth_client) { CDX::Client.auth }
-
-    it 'signing client should be multipart' do
-      expect(signin_client.savon.globals[:multipart]).to eq(true)
-    end
-
-    it 'signing client should have the right filters' do
-      expect(signin_client.savon.globals[:filters]).to include(:password, :credential, :answer)
-    end
-
-    it 'signing client should have default keys' do
-      expect(signin_client.savon.globals[:wsdl]).to eq("https://devngn.epacdxnode.net/cdx-register/services/RegisterSignService?wsdl")
-      expect(signin_client.savon.globals[:pretty_print_xml]).to_not be_nil
-      expect(signin_client.savon.globals[:log]).to_not be_nil
-      expect(signin_client.savon.globals[:soap_version]).to_not be_nil
-      expect(signin_client.savon.globals[:convert_request_keys_to]).to_not be_nil
-    end
-
-    it 'auth client should have the right filters' do
-      expect(auth_client.savon.globals[:filters]).to eq([:password])
-    end
-
-    it 'auth client should have default keys' do
-      expect(auth_client.savon.globals[:wsdl]).to eq("https://devngn.epacdxnode.net/cdx-register/services/RegisterAuthService?wsdl")
-      expect(auth_client.savon.globals[:pretty_print_xml]).to_not be_nil
-      expect(auth_client.savon.globals[:log]).to_not be_nil
-      expect(auth_client.savon.globals[:soap_version]).to_not be_nil
-      expect(auth_client.savon.globals[:convert_request_keys_to]).to_not be_nil
-    end
-  end
-
-  describe '#CDX::User.new(args, output_stream).authenticate' do
-    let(:auth_response) {
-      double('response', hash: {
-        envelope: {
-          body: {
-            authenticate_response: {
-              user: {
-                user_id: 'user_id',
-                first_name: 'first_name',
-                last_name: 'last_name',
-                middle_initial: 'middle_initial'
-              }
-            }
-          }
-        }
-      })
-    }
-
-    let(:user_input_data) {
-      {'user_id' => 'userId', 'password' => 'password'}
-    }
-
-    let(:authenticate_user_call) {
-      CDX::User.new(user_input_data, output_stream).authenticate
-    }
-
-    before do
-      allow(CDX::Client::Auth).to receive(:call).and_return(auth_response)
-    end
-
-    it 'should return a re-packaged response' do
-      expect(authenticate_user_call).to eq({
-        UserId: 'user_id',
-        FirstName: 'first_name',
-        LastName: 'last_name',
-        MiddleInitial: 'middle_initial'
-      })
-    end
-
-    it 'should call authentication with the correct stuff' do
-      expect(CDX::Client::Auth).to receive(:call).with(:authenticate, {
-        :message => {
-          :userId => 'userId', :password => 'password'
-        }
-      }).and_return(auth_response)
-      authenticate_user_call
-    end
-
-    it 'throws some debugging into stdout' do
-      authenticate_user_call
-      expect(output_stream.string).to include(user_input_data.to_s)
-      expect(output_stream.string).to include(auth_response.hash.to_s)
-    end
-  end
-
-  describe 'CDX::System.new(output_stream).authenticate' do
-    let(:operations_response) { {'some' => 'operations'} }
-
-    let(:auth_response) {
-      double('response', body: {
-        authenticate_response: {
-          security_token: 'security_token'
-        }
-      })
-    }
-
-    before do
-      allow(CDX::Client::Signin).to receive(:operations).and_return(operations_response)
-      allow(CDX::Client::Signin).to receive(:call).and_return(auth_response)
-    end
-
-    it 'makes a request for operations and logs to stdout' do
-      expect(CDX::Client::Signin).to receive(:operations).and_return(operations_response)
-      CDX::System.new(output_stream).authenticate
-      expect(output_stream.string).to include(operations_response.to_s)
-    end
-
-    it 'makes the right authentication request via the right client' do
-      expect(CDX::Client::Signin).to receive(:call).with(:authenticate, {
-        message: {
-          :userId => ENV["CDX_USERNAME"], :credential => ENV["CDX_PASSWORD"],
-          :domain => "default", :authenticationMethod => "password"
-        }
-      }).and_return(auth_response)
-      CDX::System.new(output_stream).authenticate
-    end
-
-    it 'logs the response body' do
-      CDX::System.new(output_stream).authenticate
-      expect(output_stream.string).to include(auth_response.body.to_s)
-    end
-
-    it 'returns the authentication token' do
-      expect(CDX::System.new(output_stream).authenticate).to eq('security_token')
-    end
-  end
-
-  describe 'CDX::Activity.new(args, output_stream).create' do
-    let(:auth_response) {
-      double('response', body: {
-        create_activity_with_properties_response: {
-          activity_id: 'activity_id'
-        }
-      })
-    }
-
-    let(:args) {
-      {
-        activity_description: 'activity_description',
-        role_code: 'role_code',
-        token: 'token',
-        signature_user: 'signature_user',
-        dataflow_name: 'dataflow_name'
-      }
-    }
-
-    before do
-      allow(CDX::Client::Signin).to receive(:call).and_return(auth_response)
-    end
-
-    it 'receives the right client call with the right data' do
-      expect(CDX::Client::Signin).to receive(:call) { |operation, options|
-        expect(operation).to eq(:create_activity_with_properties)
-        expect(options[:message][:securityToken]).to eq('token')
-        expect(options[:message][:signatureUser]).to eq('signature_user')
-        expect(options[:message][:dataflowName]).to eq('dataflow_name')
-        expect(options[:message][:properties].first[:Property][:Value]).to eq('activity_description')
-        expect(options[:message][:properties].last[:Property][:Value]).to eq('role_code')
-      }.and_return(auth_response)
-      CDX::Activity.new(args, output_stream).create
-    end
-
-    it 'returns the activity_id from the response' do
-      expect(CDX::Activity.new(args, output_stream).create).to eq('activity_id')
-    end
-
-    it 'logs the response body' do
-      CDX::Activity.new(args, output_stream).create
-      expect(output_stream.string).to include(auth_response.body.to_s)
-    end
-  end
-
   describe 'CDX::Question.new(opts, output_stream).get' do
     let(:opts) {
       {
@@ -215,127 +34,30 @@ describe "CDX" do
         expect(options[:message][:activityId]).to eq('activity_id')
         expect(options[:message][:userId]).to eq('UserId')
       }.and_return(auth_response)
-      CDX::Question.new(opts, output_stream).get
+      CDX::Question.new(opts, output_stream).perform
     end
 
     it 'outputs the response body' do
-      CDX::Question.new(opts, output_stream).get
+      CDX::Question.new(opts, output_stream).perform
       expect(output_stream.string).to include(auth_response.body.to_s)
     end
 
     it 'constructs a return value from the response' do
-      expect(CDX::Question.new(opts, output_stream).get).to eq({
+      expect(CDX::Question.new(opts, output_stream).perform).to eq({
         question_id: 'question_id',
         question_text: 'text'
       })
     end
   end
 
-  describe 'CDX::Authenticator.new(args, output_stream).perform' do
+  describe 'CDX::Answer.new(args, output_stream).perform' do
     let(:opts) {
-      {'user_id' => 'userId', 'password' => 'password'}
-    }
-
-    let(:user_signature) {
       {
-        UserId: 'user_id',
-        FirstName: 'first_name',
-        LastName: 'last_name',
-        MiddleInitial: 'middle_initial'
-      }
-    }
-
-    let(:security_token) { 'security_token' }
-    let(:activity_id) { 'activity_id' }
-
-    let(:question) {
-      {
+        token:  'security_token',
+        activity_id: 'activity_id',
+        user_id: 'user_id',
         question_id: 'question_id',
-        question_text: 'text'
-      }
-    }
-    
-    before do
-      allow_any_instance_of(CDX::User).to receive(:authenticate).and_return(user_signature)
-      allow_any_instance_of(CDX::System).to receive(:authenticate).and_return(security_token)
-      allow_any_instance_of(CDX::Activity).to receive(:create).and_return(activity_id)
-      allow_any_instance_of(CDX::Question).to receive(:get).and_return(question)
-    end
-
-    it 'makes the right requests' do
-      expect_any_instance_of(CDX::User).to receive(:authenticate).and_return(user_signature)
-      expect_any_instance_of(CDX::System).to receive(:authenticate).and_return(security_token)
-      expect_any_instance_of(CDX::Activity).to receive(:create).and_return(activity_id)
-      expect_any_instance_of(CDX::Question).to receive(:get).and_return(question)
-      CDX::Authenticator.new(opts, output_stream).perform
-    end
-
-    it 'returns the repackaged data' do
-      expect(CDX::Authenticator.new(opts, output_stream).perform).to eq({
-        :token => security_token,
-        :activity_id => activity_id,
-        :question => question,
-        :user_id => user_signature[:UserId]
-      })
-    end
-
-    describe 'when there is an authentication error' do
-      let(:error) {
-        e = Savon::SOAPFault.new('something went wrong', double)
-        allow(e).to receive(:to_hash).and_return({
-          fault: {
-            detail: {
-              register_auth_fault: {
-                description: 'bad credentials'
-              }
-            }
-          }
-        })
-        e
-      }
-
-      it 'logs the error' do
-        allow_any_instance_of(CDX::User).to receive(:authenticate).and_raise(error)
-        CDX::Authenticator.new(opts, output_stream).perform
-        expect(output_stream.string).to include('bad credentials')
-      end
-
-      it 'returns the error as repackaged data' do
-        allow_any_instance_of(CDX::User).to receive(:authenticate).and_raise(error)
-        expect(CDX::Authenticator.new(opts, output_stream).perform).to eq({description: 'bad credentials'})
-      end
-    end
-
-    describe 'when there is a register error' do
-      let(:error) {
-        e = Savon::SOAPFault.new('something went wrong', double)
-        allow(e).to receive(:to_hash).and_return({
-          fault: {
-            detail: {
-              register_fault: {
-                description: 'bad register???'
-              }
-            }
-          }
-        })
-        e
-      }
-
-      it 'returns the error as repackaged data' do
-        allow_any_instance_of(CDX::User).to receive(:authenticate).and_raise(error)
-        expect(CDX::Authenticator.new(opts, output_stream).perform).to eq({description: 'bad register???'})
-      end
-    end
-  end
-
-  describe 'CDX::Answer.new(args, output_stream).validate' do
-    let(:opts) {
-      {
-        'token' =>  'security_token',
-        'activity_id' => 'activity_id',
-        'user_id' => 'user_id',
-        'question_id' => 'question_id',
-        'answer' => 'answer'
+        answer: 'answer'
       }
     }
 
@@ -356,23 +78,23 @@ describe "CDX" do
     it 'sends the right request with the right data' do
       expect(CDX::Client::Signin).to receive(:call).with(:validate_answer, {
         message: {
-          :securityToken => 'security_token',
-          :activityId => 'activity_id',
-          :userId => 'user_id',
-          :questionId => 'question_id',
-          :answer => 'answer'
+          securityToken: 'security_token',
+          activityId: 'activity_id',
+          userId: 'user_id',
+          questionId: 'question_id',
+          answer: 'answer'
         }
       })
 
-      CDX::Answer.new(opts, output_stream).validate
+      CDX::Answer.new(opts, output_stream).perform
     end
 
     it 'returns the repackaged response' do
-      expect(CDX::Answer.new(opts, output_stream).validate).to eq('it is valid')
+      expect(CDX::Answer.new(opts, output_stream).perform).to eq('it is valid')
     end
 
     it 'logs response data' do
-      CDX::Answer.new(opts, output_stream).validate
+      CDX::Answer.new(opts, output_stream).perform
       expect(output_stream.string).to include('it is valid')
     end
   end
@@ -380,10 +102,10 @@ describe "CDX" do
   describe 'CDX::Sign.new(args, output_stream).perform' do
     let(:opts) {
       {
-        'id' =>  'id',
-        :manifest_content => 'content',
-        'token' => 'token',
-        'activity_id' => 'activity_id'
+        id:  'id',
+        manifest_content: 'content',
+        token: 'token',
+        activity_id: 'activity_id'
       }
     }
 
@@ -446,12 +168,12 @@ describe "CDX" do
     }
 
     before do
-      allow_any_instance_of(CDX::Answer).to receive(:validate)
+      allow_any_instance_of(CDX::Answer).to receive(:perform)
       allow_any_instance_of(CDX::Sign).to receive(:perform).and_return('document_id')
     end
 
     it 'validates the answer' do
-      expect_any_instance_of(CDX::Answer).to receive(:validate)
+      expect_any_instance_of(CDX::Answer).to receive(:perform)
       CDX::Manifest.new(opts, output_stream).sign
     end
 
@@ -461,7 +183,7 @@ describe "CDX" do
     end
 
     it 'logs the error' do
-      allow_any_instance_of(CDX::Answer).to receive(:validate).and_raise(error)
+      allow_any_instance_of(CDX::Answer).to receive(:perform).and_raise(error)
       expect(CDX::Manifest.new(opts, output_stream).sign).to eq({description: 'bad credentials'})
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -5,10 +5,12 @@ abort("DATABASE_URL environment variable is set") if ENV["DATABASE_URL"]
 
 require "rspec/rails"
 require "shoulda/matchers"
+require "shoulda/matchers"
 
 Dir[Rails.root.join("spec/support/**/*.rb")].sort.each { |file| require file }
 
 RSpec.configure do |config|
+  config.include CdxHelper
   config.infer_base_class_for_anonymous_controllers = false
   config.infer_spec_type_from_file_location!
   config.use_transactional_fixtures = false

--- a/spec/support/cdx_helper.rb
+++ b/spec/support/cdx_helper.rb
@@ -1,0 +1,5 @@
+module CdxHelper
+  def output_stream
+    @output_stream ||= StringIO.new('')
+  end
+end

--- a/spec/support/fixtures/vcr_cassettes/create_activity_with_properties.yml
+++ b/spec/support/fixtures/vcr_cassettes/create_activity_with_properties.yml
@@ -19,7 +19,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 20 Jan 2016 18:30:50 GMT
+      - Wed, 20 Jan 2016 23:31:54 GMT
       Server:
       - Apache-Coyote/1.1
       X-Frame-Options:
@@ -708,7 +708,7 @@ http_interactions:
           </wsdl:service>
         </wsdl:definitions>
     http_version: 
-  recorded_at: Wed, 20 Jan 2016 18:31:26 GMT
+  recorded_at: Wed, 20 Jan 2016 23:32:29 GMT
 - request:
     method: post
     uri: https://devngn.epacdxnode.net/cdx-register-II/services/RegisterSignService
@@ -716,241 +716,7 @@ http_interactions:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tns="http://www.exchangenetwork.net/wsdl/register/sign/1"
-        xmlns:env="http://www.w3.org/2003/05/soap-envelope"><env:Body><tns:Authenticate><userId>Emanifest_admin@epa.gov</userId><credential>Devemanifest09</credential><domain>default</domain><authenticationMethod>password</authenticationMethod></tns:Authenticate></env:Body></env:Envelope>
-    headers:
-      Soapaction:
-      - '"Authenticate"'
-      Content-Type:
-      - application/soap+xml;charset=UTF-8
-      Content-Length:
-      - '496'
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 20 Jan 2016 18:30:50 GMT
-      Server:
-      - Apache-Coyote/1.1
-      X-Frame-Options:
-      - SAMEORIGIN, SAMEORIGIN
-      Content-Type:
-      - multipart/related; type="application/xop+xml"; boundary="uuid:f10ec302-33bd-4cc5-a255-1325e4c816a1";
-        start="<root.message@cxf.apache.org>"; start-info="application/soap+xml"
-      Content-Length:
-      - '731'
-      Access-Control-Allow-Origin:
-      - "*"
-    body:
-      encoding: UTF-8
-      string: "--uuid:f10ec302-33bd-4cc5-a255-1325e4c816a1\r\nContent-Type: application/xop+xml;
-        charset=UTF-8; type=\"application/soap+xml\";\r\nContent-Transfer-Encoding:
-        binary\r\nContent-ID: <root.message@cxf.apache.org>\r\n\r\n<soap:Envelope
-        xmlns:soap=\"http://www.w3.org/2003/05/soap-envelope\"><soap:Body><ns2:AuthenticateResponse
-        xmlns:ns2=\"http://www.exchangenetwork.net/wsdl/register/sign/1\"><securityToken>fakeSecurityToken</securityToken></ns2:AuthenticateResponse></soap:Body></soap:Envelope>\r\n--uuid:f10ec302-33bd-4cc5-a255-1325e4c816a1--"
-    http_version: 
-  recorded_at: Wed, 20 Jan 2016 18:31:26 GMT
-- request:
-    method: get
-    uri: https://devngn.epacdxnode.net/cdx-register/services/RegisterAuthService?wsdl
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 20 Jan 2016 18:30:51 GMT
-      Server:
-      - Apache-Coyote/1.1
-      X-Frame-Options:
-      - SAMEORIGIN, SAMEORIGIN
-      Content-Type:
-      - text/xml
-      Access-Control-Allow-Origin:
-      - "*"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |-
-        <?xml version='1.0' encoding='UTF-8'?><wsdl:definitions xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:tns="http://www.exchangenetwork.net/wsdl/register/auth/1" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:ns1="http://schemas.xmlsoap.org/soap/http" name="RegisterAuthService" targetNamespace="http://www.exchangenetwork.net/wsdl/register/auth/1">
-          <wsdl:types>
-        <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://www.exchangenetwork.net/wsdl/register/auth/1" attributeFormDefault="unqualified" elementFormDefault="unqualified" targetNamespace="http://www.exchangenetwork.net/wsdl/register/auth/1">
-          <xs:element name="Authenticate" type="tns:Authenticate"/>
-          <xs:element name="AuthenticateResponse" type="tns:AuthenticateResponse"/>
-          <xs:complexType name="Authenticate">
-            <xs:sequence>
-              <xs:element minOccurs="0" name="userId" type="xs:string"/>
-              <xs:element minOccurs="0" name="password" type="xs:string"/>
-            </xs:sequence>
-          </xs:complexType>
-          <xs:complexType name="AuthenticateResponse">
-            <xs:sequence>
-              <xs:element minOccurs="0" name="User" type="tns:registrationUser"/>
-            </xs:sequence>
-          </xs:complexType>
-          <xs:complexType name="registrationUser">
-            <xs:sequence>
-              <xs:element minOccurs="0" name="firstName" type="xs:string"/>
-              <xs:element minOccurs="0" name="governmentPartner" type="xs:boolean"/>
-              <xs:element minOccurs="0" name="lastLogin" type="xs:dateTime"/>
-              <xs:element minOccurs="0" name="lastName" type="xs:string"/>
-              <xs:element minOccurs="0" name="legacySecretAnswer" type="xs:string"/>
-              <xs:element minOccurs="0" name="legacySecretQuestion" type="xs:string"/>
-              <xs:element minOccurs="0" name="lexisNexisAttempts" type="xs:long"/>
-              <xs:element minOccurs="0" name="middleInitial" type="xs:string"/>
-              <xs:element minOccurs="0" name="password" type="xs:string"/>
-              <xs:element minOccurs="0" name="passwordResetAttempts" type="xs:long"/>
-              <xs:element minOccurs="0" name="registrationDate" type="xs:dateTime"/>
-              <xs:element minOccurs="0" name="status" type="xs:string"/>
-              <xs:element minOccurs="0" name="suffix" type="tns:registrationUserSuffix"/>
-              <xs:element minOccurs="0" name="title" type="tns:registrationUserTitle"/>
-              <xs:element minOccurs="0" name="userId" type="xs:string"/>
-              <xs:element minOccurs="0" name="verificationIndexElectronic" type="xs:long"/>
-              <xs:element minOccurs="0" name="verificationIndexPaper" type="xs:long"/>
-            </xs:sequence>
-          </xs:complexType>
-          <xs:complexType name="registrationUserSuffix">
-            <xs:sequence>
-              <xs:element minOccurs="0" name="description" type="xs:string"/>
-            </xs:sequence>
-          </xs:complexType>
-          <xs:complexType name="registrationUserTitle">
-            <xs:sequence>
-              <xs:element minOccurs="0" name="description" type="xs:string"/>
-            </xs:sequence>
-          </xs:complexType>
-          <xs:simpleType name="RegisterAuthErrorCode">
-            <xs:restriction base="xs:string">
-              <xs:enumeration value="E_WrongIdPassword"/>
-              <xs:enumeration value="E_AccountLocked"/>
-              <xs:enumeration value="E_AccountExpired"/>
-              <xs:enumeration value="E_InternalError"/>
-            </xs:restriction>
-          </xs:simpleType>
-          <xs:element name="RegisterAuthFault" type="tns:RegisterAuthFault"/>
-          <xs:complexType name="RegisterAuthFault">
-            <xs:sequence>
-              <xs:element name="description" nillable="true" type="xs:string"/>
-              <xs:element name="errorCode" nillable="true" type="tns:RegisterAuthErrorCode"/>
-            </xs:sequence>
-          </xs:complexType>
-        </xs:schema>
-          </wsdl:types>
-          <wsdl:message name="Authenticate">
-            <wsdl:part element="tns:Authenticate" name="parameters">
-            </wsdl:part>
-          </wsdl:message>
-          <wsdl:message name="AuthenticateResponse">
-            <wsdl:part element="tns:AuthenticateResponse" name="parameters">
-            </wsdl:part>
-          </wsdl:message>
-          <wsdl:message name="RegisterAuthException">
-            <wsdl:part element="tns:RegisterAuthFault" name="RegisterAuthException">
-            </wsdl:part>
-          </wsdl:message>
-          <wsdl:portType name="RegisterAuthService">
-            <wsdl:operation name="Authenticate">
-              <wsdl:input message="tns:Authenticate" name="Authenticate">
-            </wsdl:input>
-              <wsdl:output message="tns:AuthenticateResponse" name="AuthenticateResponse">
-            </wsdl:output>
-              <wsdl:fault message="tns:RegisterAuthException" name="RegisterAuthException">
-            </wsdl:fault>
-            </wsdl:operation>
-          </wsdl:portType>
-          <wsdl:binding name="RegisterAuthServiceSoapBinding" type="tns:RegisterAuthService">
-            <soap12:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
-            <wsdl:operation name="Authenticate">
-              <soap12:operation soapAction="" style="document"/>
-              <wsdl:input name="Authenticate">
-                <soap12:body use="literal"/>
-              </wsdl:input>
-              <wsdl:output name="AuthenticateResponse">
-                <soap12:body use="literal"/>
-              </wsdl:output>
-              <wsdl:fault name="RegisterAuthException">
-                <soap12:fault name="RegisterAuthException" use="literal"/>
-              </wsdl:fault>
-            </wsdl:operation>
-          </wsdl:binding>
-          <wsdl:service name="RegisterAuthService">
-            <wsdl:port binding="tns:RegisterAuthServiceSoapBinding" name="RegisterAuthServicePort">
-              <soap12:address location="https://devngn.epacdxnode.net/cdx-register-II/services/RegisterAuthService"/>
-            </wsdl:port>
-          </wsdl:service>
-        </wsdl:definitions>
-    http_version: 
-  recorded_at: Wed, 20 Jan 2016 18:31:27 GMT
-- request:
-    method: post
-    uri: https://devngn.epacdxnode.net/cdx-register-II/services/RegisterAuthService
-    body:
-      encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tns="http://www.exchangenetwork.net/wsdl/register/auth/1"
-        xmlns:env="http://www.w3.org/2003/05/soap-envelope"><env:Body><tns:Authenticate><userId>18f_certifier</userId><password>k84jf9sh2fa3nM5</password></tns:Authenticate></env:Body></env:Envelope>
-    headers:
-      Soapaction:
-      - '"Authenticate"'
-      Content-Type:
-      - application/soap+xml;charset=UTF-8
-      Content-Length:
-      - '406'
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 20 Jan 2016 18:30:51 GMT
-      Server:
-      - Apache-Coyote/1.1
-      X-Frame-Options:
-      - SAMEORIGIN, SAMEORIGIN
-      Content-Type:
-      - application/soap+xml;charset=UTF-8
-      Content-Length:
-      - '745'
-      Access-Control-Allow-Origin:
-      - "*"
-    body:
-      encoding: UTF-8
-      string: <soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope"><soap:Body><ns2:AuthenticateResponse
-        xmlns:ns2="http://www.exchangenetwork.net/wsdl/register/auth/1"><User><firstName>Brandon</firstName><governmentPartner>false</governmentPartner><lastLogin>2016-01-20T13:30:52-05:00</lastLogin><lastName>Kirby</lastName><lexisNexisAttempts>0</lexisNexisAttempts><passwordResetAttempts>0</passwordResetAttempts><registrationDate>2015-08-21T16:11:14-04:00</registrationDate><status>Valid</status><title><description>Mr</description></title><userId>18F_CERTIFIER</userId><verificationIndexElectronic>0</verificationIndexElectronic><verificationIndexPaper>700</verificationIndexPaper></User></ns2:AuthenticateResponse></soap:Body></soap:Envelope>
-    http_version: 
-  recorded_at: Wed, 20 Jan 2016 18:31:28 GMT
-- request:
-    method: post
-    uri: https://devngn.epacdxnode.net/cdx-register-II/services/RegisterSignService
-    body:
-      encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tns="http://www.exchangenetwork.net/wsdl/register/sign/1"
-        xmlns:env="http://www.w3.org/2003/05/soap-envelope"><env:Body><tns:CreateActivityWithProperties><securityToken>fakeSecurityToken</securityToken><signatureUser><UserId>18F_CERTIFIER</UserId><FirstName>Brandon</FirstName><LastName>Kirby</LastName><MiddleInitial
+        xmlns:env="http://www.w3.org/2003/05/soap-envelope"><env:Body><tns:CreateActivityWithProperties><securityToken>fakeSecurityToken</securityToken><signatureUser><UserId>18f_certifier</UserId><FirstName>Brandon</FirstName><LastName>Kirby</LastName><MiddleInitial
         xsi:nil="true"/></signatureUser><dataflowName>eManifest</dataflowName><properties><Property><Key>activityDescription</Key><Value>development
         test</Value></Property></properties><properties><Property><Key>roleCode</Key><Value>112090</Value></Property></properties></tns:CreateActivityWithProperties></env:Body></env:Envelope>
     headers:
@@ -972,13 +738,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 20 Jan 2016 18:30:52 GMT
+      - Wed, 20 Jan 2016 23:31:55 GMT
       Server:
       - Apache-Coyote/1.1
       X-Frame-Options:
       - SAMEORIGIN, SAMEORIGIN
       Content-Type:
-      - multipart/related; type="application/xop+xml"; boundary="uuid:4e585b76-d4bf-4829-8662-4a795eb8bcc7";
+      - multipart/related; type="application/xop+xml"; boundary="uuid:55ddfaef-f0da-4ff7-a3a2-0365f9467cbb";
         start="<root.message@cxf.apache.org>"; start-info="application/soap+xml"
       Content-Length:
       - '570'
@@ -986,60 +752,11 @@ http_interactions:
       - "*"
     body:
       encoding: UTF-8
-      string: "--uuid:4e585b76-d4bf-4829-8662-4a795eb8bcc7\r\nContent-Type: application/xop+xml;
+      string: "--uuid:55ddfaef-f0da-4ff7-a3a2-0365f9467cbb\r\nContent-Type: application/xop+xml;
         charset=UTF-8; type=\"application/soap+xml\";\r\nContent-Transfer-Encoding:
         binary\r\nContent-ID: <root.message@cxf.apache.org>\r\n\r\n<soap:Envelope
         xmlns:soap=\"http://www.w3.org/2003/05/soap-envelope\"><soap:Body><ns2:CreateActivityWithPropertiesResponse
-        xmlns:ns2=\"http://www.exchangenetwork.net/wsdl/register/sign/1\"><activityId>_10b773da-0f11-45e2-af65-ffa61b3f9f2c</activityId></ns2:CreateActivityWithPropertiesResponse></soap:Body></soap:Envelope>\r\n--uuid:4e585b76-d4bf-4829-8662-4a795eb8bcc7--"
+        xmlns:ns2=\"http://www.exchangenetwork.net/wsdl/register/sign/1\"><activityId>_e88f9df3-ce3e-45bc-91ff-6c6601d85442</activityId></ns2:CreateActivityWithPropertiesResponse></soap:Body></soap:Envelope>\r\n--uuid:55ddfaef-f0da-4ff7-a3a2-0365f9467cbb--"
     http_version: 
-  recorded_at: Wed, 20 Jan 2016 18:31:28 GMT
-- request:
-    method: post
-    uri: https://devngn.epacdxnode.net/cdx-register-II/services/RegisterSignService
-    body:
-      encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tns="http://www.exchangenetwork.net/wsdl/register/sign/1"
-        xmlns:env="http://www.w3.org/2003/05/soap-envelope"><env:Body><tns:GetQuestion><securityToken>fakeSecurityToken</securityToken><activityId>_10b773da-0f11-45e2-af65-ffa61b3f9f2c</activityId><userId>18F_CERTIFIER</userId></tns:GetQuestion></env:Body></env:Envelope>
-    headers:
-      Soapaction:
-      - '"GetQuestion"'
-      Content-Type:
-      - application/soap+xml;charset=UTF-8
-      Content-Length:
-      - '685'
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 20 Jan 2016 18:30:52 GMT
-      Server:
-      - Apache-Coyote/1.1
-      X-Frame-Options:
-      - SAMEORIGIN, SAMEORIGIN
-      Content-Type:
-      - multipart/related; type="application/xop+xml"; boundary="uuid:e6c63aec-9ae2-4c51-9259-26d7329e5bb5";
-        start="<root.message@cxf.apache.org>"; start-info="application/soap+xml"
-      Content-Length:
-      - '591'
-      Access-Control-Allow-Origin:
-      - "*"
-    body:
-      encoding: UTF-8
-      string: "--uuid:e6c63aec-9ae2-4c51-9259-26d7329e5bb5\r\nContent-Type: application/xop+xml;
-        charset=UTF-8; type=\"application/soap+xml\";\r\nContent-Transfer-Encoding:
-        binary\r\nContent-ID: <root.message@cxf.apache.org>\r\n\r\n<soap:Envelope
-        xmlns:soap=\"http://www.w3.org/2003/05/soap-envelope\"><soap:Body><ns2:GetQuestionResponse
-        xmlns:ns2=\"http://www.exchangenetwork.net/wsdl/register/sign/1\"><question><questionId>1</questionId><text>What
-        is the first and middle name of your oldest sibling?</text></question></ns2:GetQuestionResponse></soap:Body></soap:Envelope>\r\n--uuid:e6c63aec-9ae2-4c51-9259-26d7329e5bb5--"
-    http_version: 
-  recorded_at: Wed, 20 Jan 2016 18:31:28 GMT
+  recorded_at: Wed, 20 Jan 2016 23:32:30 GMT
 recorded_with: VCR 3.0.1

--- a/spec/support/fixtures/vcr_cassettes/create_authenticator.yml
+++ b/spec/support/fixtures/vcr_cassettes/create_authenticator.yml
@@ -19,7 +19,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 20 Jan 2016 18:30:50 GMT
+      - Thu, 21 Jan 2016 00:28:02 GMT
       Server:
       - Apache-Coyote/1.1
       X-Frame-Options:
@@ -708,7 +708,7 @@ http_interactions:
           </wsdl:service>
         </wsdl:definitions>
     http_version: 
-  recorded_at: Wed, 20 Jan 2016 18:31:26 GMT
+  recorded_at: Thu, 21 Jan 2016 00:28:38 GMT
 - request:
     method: post
     uri: https://devngn.epacdxnode.net/cdx-register-II/services/RegisterSignService
@@ -736,13 +736,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 20 Jan 2016 18:30:50 GMT
+      - Thu, 21 Jan 2016 00:28:02 GMT
       Server:
       - Apache-Coyote/1.1
       X-Frame-Options:
       - SAMEORIGIN, SAMEORIGIN
       Content-Type:
-      - multipart/related; type="application/xop+xml"; boundary="uuid:f10ec302-33bd-4cc5-a255-1325e4c816a1";
+      - multipart/related; type="application/xop+xml"; boundary="uuid:2a14cc47-b9cd-42f7-970d-b3ba031fc2dd";
         start="<root.message@cxf.apache.org>"; start-info="application/soap+xml"
       Content-Length:
       - '731'
@@ -750,13 +750,13 @@ http_interactions:
       - "*"
     body:
       encoding: UTF-8
-      string: "--uuid:f10ec302-33bd-4cc5-a255-1325e4c816a1\r\nContent-Type: application/xop+xml;
+      string: "--uuid:2a14cc47-b9cd-42f7-970d-b3ba031fc2dd\r\nContent-Type: application/xop+xml;
         charset=UTF-8; type=\"application/soap+xml\";\r\nContent-Transfer-Encoding:
         binary\r\nContent-ID: <root.message@cxf.apache.org>\r\n\r\n<soap:Envelope
         xmlns:soap=\"http://www.w3.org/2003/05/soap-envelope\"><soap:Body><ns2:AuthenticateResponse
-        xmlns:ns2=\"http://www.exchangenetwork.net/wsdl/register/sign/1\"><securityToken>fakeSecurityToken</securityToken></ns2:AuthenticateResponse></soap:Body></soap:Envelope>\r\n--uuid:f10ec302-33bd-4cc5-a255-1325e4c816a1--"
+        xmlns:ns2=\"http://www.exchangenetwork.net/wsdl/register/sign/1\"><securityToken>fakeSecurityToken</securityToken></ns2:AuthenticateResponse></soap:Body></soap:Envelope>\r\n--uuid:2a14cc47-b9cd-42f7-970d-b3ba031fc2dd--"
     http_version: 
-  recorded_at: Wed, 20 Jan 2016 18:31:26 GMT
+  recorded_at: Thu, 21 Jan 2016 00:28:39 GMT
 - request:
     method: get
     uri: https://devngn.epacdxnode.net/cdx-register/services/RegisterAuthService?wsdl
@@ -776,7 +776,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 20 Jan 2016 18:30:51 GMT
+      - Thu, 21 Jan 2016 00:28:04 GMT
       Server:
       - Apache-Coyote/1.1
       X-Frame-Options:
@@ -898,7 +898,7 @@ http_interactions:
           </wsdl:service>
         </wsdl:definitions>
     http_version: 
-  recorded_at: Wed, 20 Jan 2016 18:31:27 GMT
+  recorded_at: Thu, 21 Jan 2016 00:28:39 GMT
 - request:
     method: post
     uri: https://devngn.epacdxnode.net/cdx-register-II/services/RegisterAuthService
@@ -906,7 +906,7 @@ http_interactions:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tns="http://www.exchangenetwork.net/wsdl/register/auth/1"
-        xmlns:env="http://www.w3.org/2003/05/soap-envelope"><env:Body><tns:Authenticate><userId>18f_certifier</userId><password>k84jf9sh2fa3nM5</password></tns:Authenticate></env:Body></env:Envelope>
+        xmlns:env="http://www.w3.org/2003/05/soap-envelope"><env:Body><tns:Authenticate><userId>fakeUserId</userId><password>fakePassword</password></tns:Authenticate></env:Body></env:Envelope>
     headers:
       Soapaction:
       - '"Authenticate"'
@@ -926,7 +926,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 20 Jan 2016 18:30:51 GMT
+      - Thu, 21 Jan 2016 00:28:04 GMT
       Server:
       - Apache-Coyote/1.1
       X-Frame-Options:
@@ -940,9 +940,9 @@ http_interactions:
     body:
       encoding: UTF-8
       string: <soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope"><soap:Body><ns2:AuthenticateResponse
-        xmlns:ns2="http://www.exchangenetwork.net/wsdl/register/auth/1"><User><firstName>Brandon</firstName><governmentPartner>false</governmentPartner><lastLogin>2016-01-20T13:30:52-05:00</lastLogin><lastName>Kirby</lastName><lexisNexisAttempts>0</lexisNexisAttempts><passwordResetAttempts>0</passwordResetAttempts><registrationDate>2015-08-21T16:11:14-04:00</registrationDate><status>Valid</status><title><description>Mr</description></title><userId>18F_CERTIFIER</userId><verificationIndexElectronic>0</verificationIndexElectronic><verificationIndexPaper>700</verificationIndexPaper></User></ns2:AuthenticateResponse></soap:Body></soap:Envelope>
+        xmlns:ns2="http://www.exchangenetwork.net/wsdl/register/auth/1"><User><firstName>Brandon</firstName><governmentPartner>false</governmentPartner><lastLogin>2016-01-20T19:28:04-05:00</lastLogin><lastName>Kirby</lastName><lexisNexisAttempts>0</lexisNexisAttempts><passwordResetAttempts>0</passwordResetAttempts><registrationDate>2015-08-21T16:11:14-04:00</registrationDate><status>Valid</status><title><description>Mr</description></title><userId>fakeUserId</userId><verificationIndexElectronic>0</verificationIndexElectronic><verificationIndexPaper>700</verificationIndexPaper></User></ns2:AuthenticateResponse></soap:Body></soap:Envelope>
     http_version: 
-  recorded_at: Wed, 20 Jan 2016 18:31:28 GMT
+  recorded_at: Thu, 21 Jan 2016 00:28:40 GMT
 - request:
     method: post
     uri: https://devngn.epacdxnode.net/cdx-register-II/services/RegisterSignService
@@ -950,7 +950,7 @@ http_interactions:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tns="http://www.exchangenetwork.net/wsdl/register/sign/1"
-        xmlns:env="http://www.w3.org/2003/05/soap-envelope"><env:Body><tns:CreateActivityWithProperties><securityToken>fakeSecurityToken</securityToken><signatureUser><UserId>18F_CERTIFIER</UserId><FirstName>Brandon</FirstName><LastName>Kirby</LastName><MiddleInitial
+        xmlns:env="http://www.w3.org/2003/05/soap-envelope"><env:Body><tns:CreateActivityWithProperties><securityToken>fakeSecurityToken</securityToken><signatureUser><UserId>fakeUserId</UserId><FirstName>Brandon</FirstName><LastName>Kirby</LastName><MiddleInitial
         xsi:nil="true"/></signatureUser><dataflowName>eManifest</dataflowName><properties><Property><Key>activityDescription</Key><Value>development
         test</Value></Property></properties><properties><Property><Key>roleCode</Key><Value>112090</Value></Property></properties></tns:CreateActivityWithProperties></env:Body></env:Envelope>
     headers:
@@ -972,13 +972,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 20 Jan 2016 18:30:52 GMT
+      - Thu, 21 Jan 2016 00:28:05 GMT
       Server:
       - Apache-Coyote/1.1
       X-Frame-Options:
       - SAMEORIGIN, SAMEORIGIN
       Content-Type:
-      - multipart/related; type="application/xop+xml"; boundary="uuid:4e585b76-d4bf-4829-8662-4a795eb8bcc7";
+      - multipart/related; type="application/xop+xml"; boundary="uuid:3a5c5aba-dd32-41cc-9f12-49b7026338a3";
         start="<root.message@cxf.apache.org>"; start-info="application/soap+xml"
       Content-Length:
       - '570'
@@ -986,13 +986,13 @@ http_interactions:
       - "*"
     body:
       encoding: UTF-8
-      string: "--uuid:4e585b76-d4bf-4829-8662-4a795eb8bcc7\r\nContent-Type: application/xop+xml;
+      string: "--uuid:3a5c5aba-dd32-41cc-9f12-49b7026338a3\r\nContent-Type: application/xop+xml;
         charset=UTF-8; type=\"application/soap+xml\";\r\nContent-Transfer-Encoding:
         binary\r\nContent-ID: <root.message@cxf.apache.org>\r\n\r\n<soap:Envelope
         xmlns:soap=\"http://www.w3.org/2003/05/soap-envelope\"><soap:Body><ns2:CreateActivityWithPropertiesResponse
-        xmlns:ns2=\"http://www.exchangenetwork.net/wsdl/register/sign/1\"><activityId>_10b773da-0f11-45e2-af65-ffa61b3f9f2c</activityId></ns2:CreateActivityWithPropertiesResponse></soap:Body></soap:Envelope>\r\n--uuid:4e585b76-d4bf-4829-8662-4a795eb8bcc7--"
+        xmlns:ns2=\"http://www.exchangenetwork.net/wsdl/register/sign/1\"><activityId>fakeActivityId</activityId></ns2:CreateActivityWithPropertiesResponse></soap:Body></soap:Envelope>\r\n--uuid:3a5c5aba-dd32-41cc-9f12-49b7026338a3--"
     http_version: 
-  recorded_at: Wed, 20 Jan 2016 18:31:28 GMT
+  recorded_at: Thu, 21 Jan 2016 00:28:40 GMT
 - request:
     method: post
     uri: https://devngn.epacdxnode.net/cdx-register-II/services/RegisterSignService
@@ -1000,7 +1000,7 @@ http_interactions:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tns="http://www.exchangenetwork.net/wsdl/register/sign/1"
-        xmlns:env="http://www.w3.org/2003/05/soap-envelope"><env:Body><tns:GetQuestion><securityToken>fakeSecurityToken</securityToken><activityId>_10b773da-0f11-45e2-af65-ffa61b3f9f2c</activityId><userId>18F_CERTIFIER</userId></tns:GetQuestion></env:Body></env:Envelope>
+        xmlns:env="http://www.w3.org/2003/05/soap-envelope"><env:Body><tns:GetQuestion><securityToken>fakeSecurityToken</securityToken><activityId>fakeActivityId</activityId><userId>fakeUserId</userId></tns:GetQuestion></env:Body></env:Envelope>
     headers:
       Soapaction:
       - '"GetQuestion"'
@@ -1020,13 +1020,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 20 Jan 2016 18:30:52 GMT
+      - Thu, 21 Jan 2016 00:28:05 GMT
       Server:
       - Apache-Coyote/1.1
       X-Frame-Options:
       - SAMEORIGIN, SAMEORIGIN
       Content-Type:
-      - multipart/related; type="application/xop+xml"; boundary="uuid:e6c63aec-9ae2-4c51-9259-26d7329e5bb5";
+      - multipart/related; type="application/xop+xml"; boundary="uuid:be936d19-138d-4969-af4e-214d230d5819";
         start="<root.message@cxf.apache.org>"; start-info="application/soap+xml"
       Content-Length:
       - '591'
@@ -1034,12 +1034,12 @@ http_interactions:
       - "*"
     body:
       encoding: UTF-8
-      string: "--uuid:e6c63aec-9ae2-4c51-9259-26d7329e5bb5\r\nContent-Type: application/xop+xml;
+      string: "--uuid:be936d19-138d-4969-af4e-214d230d5819\r\nContent-Type: application/xop+xml;
         charset=UTF-8; type=\"application/soap+xml\";\r\nContent-Transfer-Encoding:
         binary\r\nContent-ID: <root.message@cxf.apache.org>\r\n\r\n<soap:Envelope
         xmlns:soap=\"http://www.w3.org/2003/05/soap-envelope\"><soap:Body><ns2:GetQuestionResponse
         xmlns:ns2=\"http://www.exchangenetwork.net/wsdl/register/sign/1\"><question><questionId>1</questionId><text>What
-        is the first and middle name of your oldest sibling?</text></question></ns2:GetQuestionResponse></soap:Body></soap:Envelope>\r\n--uuid:e6c63aec-9ae2-4c51-9259-26d7329e5bb5--"
+        is the first and middle name of your oldest sibling?</text></question></ns2:GetQuestionResponse></soap:Body></soap:Envelope>\r\n--uuid:be936d19-138d-4969-af4e-214d230d5819--"
     http_version: 
-  recorded_at: Wed, 20 Jan 2016 18:31:28 GMT
+  recorded_at: Thu, 21 Jan 2016 00:28:41 GMT
 recorded_with: VCR 3.0.1

--- a/spec/support/fixtures/vcr_cassettes/create_authenticator_with_register_error.yml
+++ b/spec/support/fixtures/vcr_cassettes/create_authenticator_with_register_error.yml
@@ -19,7 +19,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 20 Jan 2016 18:30:50 GMT
+      - Thu, 21 Jan 2016 00:45:35 GMT
       Server:
       - Apache-Coyote/1.1
       X-Frame-Options:
@@ -708,7 +708,7 @@ http_interactions:
           </wsdl:service>
         </wsdl:definitions>
     http_version: 
-  recorded_at: Wed, 20 Jan 2016 18:31:26 GMT
+  recorded_at: Thu, 21 Jan 2016 00:46:11 GMT
 - request:
     method: post
     uri: https://devngn.epacdxnode.net/cdx-register-II/services/RegisterSignService
@@ -716,14 +716,14 @@ http_interactions:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tns="http://www.exchangenetwork.net/wsdl/register/sign/1"
-        xmlns:env="http://www.w3.org/2003/05/soap-envelope"><env:Body><tns:Authenticate><userId>Emanifest_admin@epa.gov</userId><credential>Devemanifest09</credential><domain>default</domain><authenticationMethod>password</authenticationMethod></tns:Authenticate></env:Body></env:Envelope>
+        xmlns:env="http://www.w3.org/2003/05/soap-envelope"><env:Body><tns:Authenticate><userId>change_me</userId><credential>change_me</credential><domain>default</domain><authenticationMethod>password</authenticationMethod></tns:Authenticate></env:Body></env:Envelope>
     headers:
       Soapaction:
       - '"Authenticate"'
       Content-Type:
       - application/soap+xml;charset=UTF-8
       Content-Length:
-      - '496'
+      - '477'
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -732,314 +732,37 @@ http_interactions:
       - Ruby
   response:
     status:
-      code: 200
-      message: OK
+      code: 500
+      message: Internal Server Error
     headers:
       Date:
-      - Wed, 20 Jan 2016 18:30:50 GMT
+      - Thu, 21 Jan 2016 00:45:35 GMT
       Server:
       - Apache-Coyote/1.1
       X-Frame-Options:
       - SAMEORIGIN, SAMEORIGIN
       Content-Type:
-      - multipart/related; type="application/xop+xml"; boundary="uuid:f10ec302-33bd-4cc5-a255-1325e4c816a1";
+      - multipart/related; type="application/xop+xml"; boundary="uuid:3fbadf41-5eb0-4e8a-a810-348be99ac1ba";
         start="<root.message@cxf.apache.org>"; start-info="application/soap+xml"
       Content-Length:
-      - '731'
+      - '1105'
       Access-Control-Allow-Origin:
       - "*"
+      Connection:
+      - close
     body:
       encoding: UTF-8
-      string: "--uuid:f10ec302-33bd-4cc5-a255-1325e4c816a1\r\nContent-Type: application/xop+xml;
+      string: "--uuid:3fbadf41-5eb0-4e8a-a810-348be99ac1ba\r\nContent-Type: application/xop+xml;
         charset=UTF-8; type=\"application/soap+xml\";\r\nContent-Transfer-Encoding:
         binary\r\nContent-ID: <root.message@cxf.apache.org>\r\n\r\n<soap:Envelope
-        xmlns:soap=\"http://www.w3.org/2003/05/soap-envelope\"><soap:Body><ns2:AuthenticateResponse
-        xmlns:ns2=\"http://www.exchangenetwork.net/wsdl/register/sign/1\"><securityToken>fakeSecurityToken</securityToken></ns2:AuthenticateResponse></soap:Body></soap:Envelope>\r\n--uuid:f10ec302-33bd-4cc5-a255-1325e4c816a1--"
+        xmlns:soap=\"http://www.w3.org/2003/05/soap-envelope\"><soap:Body><soap:Fault><soap:Code><soap:Value>soap:Receiver</soap:Value></soap:Code><soap:Reason><soap:Text
+        xml:lang=\"en\">Fault occurred while processing.</soap:Text></soap:Reason><soap:Detail><ns1:RegisterFault
+        xmlns:ns1=\"http://www.exchangenetwork.net/wsdl/register/sign/1\"><description
+        xmlns:ns2=\"http://www.exchangenetwork.net/wsdl/register/sign/1\">Unable to
+        authenticate user - The user account could not be located. Could not perform
+        central authentication for user &lt;change_me> in domain &lt;default></description><errorCode
+        xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:ns2=\"http://www.exchangenetwork.net/wsdl/register/sign/1\"
+        xsi:type=\"ns2:RegisterErrorCode\">E_UnknownUser</errorCode></ns1:RegisterFault></soap:Detail></soap:Fault></soap:Body></soap:Envelope>\r\n--uuid:3fbadf41-5eb0-4e8a-a810-348be99ac1ba--"
     http_version: 
-  recorded_at: Wed, 20 Jan 2016 18:31:26 GMT
-- request:
-    method: get
-    uri: https://devngn.epacdxnode.net/cdx-register/services/RegisterAuthService?wsdl
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 20 Jan 2016 18:30:51 GMT
-      Server:
-      - Apache-Coyote/1.1
-      X-Frame-Options:
-      - SAMEORIGIN, SAMEORIGIN
-      Content-Type:
-      - text/xml
-      Access-Control-Allow-Origin:
-      - "*"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |-
-        <?xml version='1.0' encoding='UTF-8'?><wsdl:definitions xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:tns="http://www.exchangenetwork.net/wsdl/register/auth/1" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:ns1="http://schemas.xmlsoap.org/soap/http" name="RegisterAuthService" targetNamespace="http://www.exchangenetwork.net/wsdl/register/auth/1">
-          <wsdl:types>
-        <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://www.exchangenetwork.net/wsdl/register/auth/1" attributeFormDefault="unqualified" elementFormDefault="unqualified" targetNamespace="http://www.exchangenetwork.net/wsdl/register/auth/1">
-          <xs:element name="Authenticate" type="tns:Authenticate"/>
-          <xs:element name="AuthenticateResponse" type="tns:AuthenticateResponse"/>
-          <xs:complexType name="Authenticate">
-            <xs:sequence>
-              <xs:element minOccurs="0" name="userId" type="xs:string"/>
-              <xs:element minOccurs="0" name="password" type="xs:string"/>
-            </xs:sequence>
-          </xs:complexType>
-          <xs:complexType name="AuthenticateResponse">
-            <xs:sequence>
-              <xs:element minOccurs="0" name="User" type="tns:registrationUser"/>
-            </xs:sequence>
-          </xs:complexType>
-          <xs:complexType name="registrationUser">
-            <xs:sequence>
-              <xs:element minOccurs="0" name="firstName" type="xs:string"/>
-              <xs:element minOccurs="0" name="governmentPartner" type="xs:boolean"/>
-              <xs:element minOccurs="0" name="lastLogin" type="xs:dateTime"/>
-              <xs:element minOccurs="0" name="lastName" type="xs:string"/>
-              <xs:element minOccurs="0" name="legacySecretAnswer" type="xs:string"/>
-              <xs:element minOccurs="0" name="legacySecretQuestion" type="xs:string"/>
-              <xs:element minOccurs="0" name="lexisNexisAttempts" type="xs:long"/>
-              <xs:element minOccurs="0" name="middleInitial" type="xs:string"/>
-              <xs:element minOccurs="0" name="password" type="xs:string"/>
-              <xs:element minOccurs="0" name="passwordResetAttempts" type="xs:long"/>
-              <xs:element minOccurs="0" name="registrationDate" type="xs:dateTime"/>
-              <xs:element minOccurs="0" name="status" type="xs:string"/>
-              <xs:element minOccurs="0" name="suffix" type="tns:registrationUserSuffix"/>
-              <xs:element minOccurs="0" name="title" type="tns:registrationUserTitle"/>
-              <xs:element minOccurs="0" name="userId" type="xs:string"/>
-              <xs:element minOccurs="0" name="verificationIndexElectronic" type="xs:long"/>
-              <xs:element minOccurs="0" name="verificationIndexPaper" type="xs:long"/>
-            </xs:sequence>
-          </xs:complexType>
-          <xs:complexType name="registrationUserSuffix">
-            <xs:sequence>
-              <xs:element minOccurs="0" name="description" type="xs:string"/>
-            </xs:sequence>
-          </xs:complexType>
-          <xs:complexType name="registrationUserTitle">
-            <xs:sequence>
-              <xs:element minOccurs="0" name="description" type="xs:string"/>
-            </xs:sequence>
-          </xs:complexType>
-          <xs:simpleType name="RegisterAuthErrorCode">
-            <xs:restriction base="xs:string">
-              <xs:enumeration value="E_WrongIdPassword"/>
-              <xs:enumeration value="E_AccountLocked"/>
-              <xs:enumeration value="E_AccountExpired"/>
-              <xs:enumeration value="E_InternalError"/>
-            </xs:restriction>
-          </xs:simpleType>
-          <xs:element name="RegisterAuthFault" type="tns:RegisterAuthFault"/>
-          <xs:complexType name="RegisterAuthFault">
-            <xs:sequence>
-              <xs:element name="description" nillable="true" type="xs:string"/>
-              <xs:element name="errorCode" nillable="true" type="tns:RegisterAuthErrorCode"/>
-            </xs:sequence>
-          </xs:complexType>
-        </xs:schema>
-          </wsdl:types>
-          <wsdl:message name="Authenticate">
-            <wsdl:part element="tns:Authenticate" name="parameters">
-            </wsdl:part>
-          </wsdl:message>
-          <wsdl:message name="AuthenticateResponse">
-            <wsdl:part element="tns:AuthenticateResponse" name="parameters">
-            </wsdl:part>
-          </wsdl:message>
-          <wsdl:message name="RegisterAuthException">
-            <wsdl:part element="tns:RegisterAuthFault" name="RegisterAuthException">
-            </wsdl:part>
-          </wsdl:message>
-          <wsdl:portType name="RegisterAuthService">
-            <wsdl:operation name="Authenticate">
-              <wsdl:input message="tns:Authenticate" name="Authenticate">
-            </wsdl:input>
-              <wsdl:output message="tns:AuthenticateResponse" name="AuthenticateResponse">
-            </wsdl:output>
-              <wsdl:fault message="tns:RegisterAuthException" name="RegisterAuthException">
-            </wsdl:fault>
-            </wsdl:operation>
-          </wsdl:portType>
-          <wsdl:binding name="RegisterAuthServiceSoapBinding" type="tns:RegisterAuthService">
-            <soap12:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
-            <wsdl:operation name="Authenticate">
-              <soap12:operation soapAction="" style="document"/>
-              <wsdl:input name="Authenticate">
-                <soap12:body use="literal"/>
-              </wsdl:input>
-              <wsdl:output name="AuthenticateResponse">
-                <soap12:body use="literal"/>
-              </wsdl:output>
-              <wsdl:fault name="RegisterAuthException">
-                <soap12:fault name="RegisterAuthException" use="literal"/>
-              </wsdl:fault>
-            </wsdl:operation>
-          </wsdl:binding>
-          <wsdl:service name="RegisterAuthService">
-            <wsdl:port binding="tns:RegisterAuthServiceSoapBinding" name="RegisterAuthServicePort">
-              <soap12:address location="https://devngn.epacdxnode.net/cdx-register-II/services/RegisterAuthService"/>
-            </wsdl:port>
-          </wsdl:service>
-        </wsdl:definitions>
-    http_version: 
-  recorded_at: Wed, 20 Jan 2016 18:31:27 GMT
-- request:
-    method: post
-    uri: https://devngn.epacdxnode.net/cdx-register-II/services/RegisterAuthService
-    body:
-      encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tns="http://www.exchangenetwork.net/wsdl/register/auth/1"
-        xmlns:env="http://www.w3.org/2003/05/soap-envelope"><env:Body><tns:Authenticate><userId>18f_certifier</userId><password>k84jf9sh2fa3nM5</password></tns:Authenticate></env:Body></env:Envelope>
-    headers:
-      Soapaction:
-      - '"Authenticate"'
-      Content-Type:
-      - application/soap+xml;charset=UTF-8
-      Content-Length:
-      - '406'
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 20 Jan 2016 18:30:51 GMT
-      Server:
-      - Apache-Coyote/1.1
-      X-Frame-Options:
-      - SAMEORIGIN, SAMEORIGIN
-      Content-Type:
-      - application/soap+xml;charset=UTF-8
-      Content-Length:
-      - '745'
-      Access-Control-Allow-Origin:
-      - "*"
-    body:
-      encoding: UTF-8
-      string: <soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope"><soap:Body><ns2:AuthenticateResponse
-        xmlns:ns2="http://www.exchangenetwork.net/wsdl/register/auth/1"><User><firstName>Brandon</firstName><governmentPartner>false</governmentPartner><lastLogin>2016-01-20T13:30:52-05:00</lastLogin><lastName>Kirby</lastName><lexisNexisAttempts>0</lexisNexisAttempts><passwordResetAttempts>0</passwordResetAttempts><registrationDate>2015-08-21T16:11:14-04:00</registrationDate><status>Valid</status><title><description>Mr</description></title><userId>18F_CERTIFIER</userId><verificationIndexElectronic>0</verificationIndexElectronic><verificationIndexPaper>700</verificationIndexPaper></User></ns2:AuthenticateResponse></soap:Body></soap:Envelope>
-    http_version: 
-  recorded_at: Wed, 20 Jan 2016 18:31:28 GMT
-- request:
-    method: post
-    uri: https://devngn.epacdxnode.net/cdx-register-II/services/RegisterSignService
-    body:
-      encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tns="http://www.exchangenetwork.net/wsdl/register/sign/1"
-        xmlns:env="http://www.w3.org/2003/05/soap-envelope"><env:Body><tns:CreateActivityWithProperties><securityToken>fakeSecurityToken</securityToken><signatureUser><UserId>18F_CERTIFIER</UserId><FirstName>Brandon</FirstName><LastName>Kirby</LastName><MiddleInitial
-        xsi:nil="true"/></signatureUser><dataflowName>eManifest</dataflowName><properties><Property><Key>activityDescription</Key><Value>development
-        test</Value></Property></properties><properties><Property><Key>roleCode</Key><Value>112090</Value></Property></properties></tns:CreateActivityWithProperties></env:Body></env:Envelope>
-    headers:
-      Soapaction:
-      - '"CreateActivityWithProperties"'
-      Content-Type:
-      - application/soap+xml;charset=UTF-8
-      Content-Length:
-      - '1006'
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 20 Jan 2016 18:30:52 GMT
-      Server:
-      - Apache-Coyote/1.1
-      X-Frame-Options:
-      - SAMEORIGIN, SAMEORIGIN
-      Content-Type:
-      - multipart/related; type="application/xop+xml"; boundary="uuid:4e585b76-d4bf-4829-8662-4a795eb8bcc7";
-        start="<root.message@cxf.apache.org>"; start-info="application/soap+xml"
-      Content-Length:
-      - '570'
-      Access-Control-Allow-Origin:
-      - "*"
-    body:
-      encoding: UTF-8
-      string: "--uuid:4e585b76-d4bf-4829-8662-4a795eb8bcc7\r\nContent-Type: application/xop+xml;
-        charset=UTF-8; type=\"application/soap+xml\";\r\nContent-Transfer-Encoding:
-        binary\r\nContent-ID: <root.message@cxf.apache.org>\r\n\r\n<soap:Envelope
-        xmlns:soap=\"http://www.w3.org/2003/05/soap-envelope\"><soap:Body><ns2:CreateActivityWithPropertiesResponse
-        xmlns:ns2=\"http://www.exchangenetwork.net/wsdl/register/sign/1\"><activityId>_10b773da-0f11-45e2-af65-ffa61b3f9f2c</activityId></ns2:CreateActivityWithPropertiesResponse></soap:Body></soap:Envelope>\r\n--uuid:4e585b76-d4bf-4829-8662-4a795eb8bcc7--"
-    http_version: 
-  recorded_at: Wed, 20 Jan 2016 18:31:28 GMT
-- request:
-    method: post
-    uri: https://devngn.epacdxnode.net/cdx-register-II/services/RegisterSignService
-    body:
-      encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tns="http://www.exchangenetwork.net/wsdl/register/sign/1"
-        xmlns:env="http://www.w3.org/2003/05/soap-envelope"><env:Body><tns:GetQuestion><securityToken>fakeSecurityToken</securityToken><activityId>_10b773da-0f11-45e2-af65-ffa61b3f9f2c</activityId><userId>18F_CERTIFIER</userId></tns:GetQuestion></env:Body></env:Envelope>
-    headers:
-      Soapaction:
-      - '"GetQuestion"'
-      Content-Type:
-      - application/soap+xml;charset=UTF-8
-      Content-Length:
-      - '685'
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 20 Jan 2016 18:30:52 GMT
-      Server:
-      - Apache-Coyote/1.1
-      X-Frame-Options:
-      - SAMEORIGIN, SAMEORIGIN
-      Content-Type:
-      - multipart/related; type="application/xop+xml"; boundary="uuid:e6c63aec-9ae2-4c51-9259-26d7329e5bb5";
-        start="<root.message@cxf.apache.org>"; start-info="application/soap+xml"
-      Content-Length:
-      - '591'
-      Access-Control-Allow-Origin:
-      - "*"
-    body:
-      encoding: UTF-8
-      string: "--uuid:e6c63aec-9ae2-4c51-9259-26d7329e5bb5\r\nContent-Type: application/xop+xml;
-        charset=UTF-8; type=\"application/soap+xml\";\r\nContent-Transfer-Encoding:
-        binary\r\nContent-ID: <root.message@cxf.apache.org>\r\n\r\n<soap:Envelope
-        xmlns:soap=\"http://www.w3.org/2003/05/soap-envelope\"><soap:Body><ns2:GetQuestionResponse
-        xmlns:ns2=\"http://www.exchangenetwork.net/wsdl/register/sign/1\"><question><questionId>1</questionId><text>What
-        is the first and middle name of your oldest sibling?</text></question></ns2:GetQuestionResponse></soap:Body></soap:Envelope>\r\n--uuid:e6c63aec-9ae2-4c51-9259-26d7329e5bb5--"
-    http_version: 
-  recorded_at: Wed, 20 Jan 2016 18:31:28 GMT
+  recorded_at: Thu, 21 Jan 2016 00:46:11 GMT
 recorded_with: VCR 3.0.1

--- a/spec/support/fixtures/vcr_cassettes/create_authenticator_with_wrong_password.yml
+++ b/spec/support/fixtures/vcr_cassettes/create_authenticator_with_wrong_password.yml
@@ -19,7 +19,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 20 Jan 2016 18:30:50 GMT
+      - Thu, 21 Jan 2016 00:42:47 GMT
       Server:
       - Apache-Coyote/1.1
       X-Frame-Options:
@@ -708,7 +708,7 @@ http_interactions:
           </wsdl:service>
         </wsdl:definitions>
     http_version: 
-  recorded_at: Wed, 20 Jan 2016 18:31:26 GMT
+  recorded_at: Thu, 21 Jan 2016 00:43:23 GMT
 - request:
     method: post
     uri: https://devngn.epacdxnode.net/cdx-register-II/services/RegisterSignService
@@ -736,13 +736,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 20 Jan 2016 18:30:50 GMT
+      - Thu, 21 Jan 2016 00:42:47 GMT
       Server:
       - Apache-Coyote/1.1
       X-Frame-Options:
       - SAMEORIGIN, SAMEORIGIN
       Content-Type:
-      - multipart/related; type="application/xop+xml"; boundary="uuid:f10ec302-33bd-4cc5-a255-1325e4c816a1";
+      - multipart/related; type="application/xop+xml"; boundary="uuid:a7020688-9975-4427-8950-401a4063231f";
         start="<root.message@cxf.apache.org>"; start-info="application/soap+xml"
       Content-Length:
       - '731'
@@ -750,13 +750,13 @@ http_interactions:
       - "*"
     body:
       encoding: UTF-8
-      string: "--uuid:f10ec302-33bd-4cc5-a255-1325e4c816a1\r\nContent-Type: application/xop+xml;
+      string: "--uuid:a7020688-9975-4427-8950-401a4063231f\r\nContent-Type: application/xop+xml;
         charset=UTF-8; type=\"application/soap+xml\";\r\nContent-Transfer-Encoding:
         binary\r\nContent-ID: <root.message@cxf.apache.org>\r\n\r\n<soap:Envelope
         xmlns:soap=\"http://www.w3.org/2003/05/soap-envelope\"><soap:Body><ns2:AuthenticateResponse
-        xmlns:ns2=\"http://www.exchangenetwork.net/wsdl/register/sign/1\"><securityToken>fakeSecurityToken</securityToken></ns2:AuthenticateResponse></soap:Body></soap:Envelope>\r\n--uuid:f10ec302-33bd-4cc5-a255-1325e4c816a1--"
+        xmlns:ns2=\"http://www.exchangenetwork.net/wsdl/register/sign/1\"><securityToken>csm:IiKaBeCRDqLQCDSlyPFQ5L2Wh58w_dbWJ6Vv1CCqcOgJH-GgGOBnI1P3PlH4UTzq.5zSAx_QQQqT042Z7Uhro_dW9mNLtYcbR5BFL3382XXS5e_TzviVG3OHFLt-yoNYx.Hm_OGCWOpkLW7quPpdXA6BYScxUIpnMFvc-MC_-xLFrpOx2dCYITza4dcGdncLDw.czqkQA8D3S6BtzJcrXjYTQ,,.</securityToken></ns2:AuthenticateResponse></soap:Body></soap:Envelope>\r\n--uuid:a7020688-9975-4427-8950-401a4063231f--"
     http_version: 
-  recorded_at: Wed, 20 Jan 2016 18:31:26 GMT
+  recorded_at: Thu, 21 Jan 2016 00:43:24 GMT
 - request:
     method: get
     uri: https://devngn.epacdxnode.net/cdx-register/services/RegisterAuthService?wsdl
@@ -776,7 +776,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 20 Jan 2016 18:30:51 GMT
+      - Thu, 21 Jan 2016 00:42:49 GMT
       Server:
       - Apache-Coyote/1.1
       X-Frame-Options:
@@ -898,7 +898,7 @@ http_interactions:
           </wsdl:service>
         </wsdl:definitions>
     http_version: 
-  recorded_at: Wed, 20 Jan 2016 18:31:27 GMT
+  recorded_at: Thu, 21 Jan 2016 00:43:24 GMT
 - request:
     method: post
     uri: https://devngn.epacdxnode.net/cdx-register-II/services/RegisterAuthService
@@ -906,14 +906,14 @@ http_interactions:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tns="http://www.exchangenetwork.net/wsdl/register/auth/1"
-        xmlns:env="http://www.w3.org/2003/05/soap-envelope"><env:Body><tns:Authenticate><userId>18f_certifier</userId><password>k84jf9sh2fa3nM5</password></tns:Authenticate></env:Body></env:Envelope>
+        xmlns:env="http://www.w3.org/2003/05/soap-envelope"><env:Body><tns:Authenticate><userId>real_user_id</userId><password>wrong</password></tns:Authenticate></env:Body></env:Envelope>
     headers:
       Soapaction:
       - '"Authenticate"'
       Content-Type:
       - application/soap+xml;charset=UTF-8
       Content-Length:
-      - '406'
+      - '396'
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -922,11 +922,11 @@ http_interactions:
       - Ruby
   response:
     status:
-      code: 200
-      message: OK
+      code: 500
+      message: Internal Server Error
     headers:
       Date:
-      - Wed, 20 Jan 2016 18:30:51 GMT
+      - Thu, 21 Jan 2016 00:42:49 GMT
       Server:
       - Apache-Coyote/1.1
       X-Frame-Options:
@@ -934,112 +934,19 @@ http_interactions:
       Content-Type:
       - application/soap+xml;charset=UTF-8
       Content-Length:
-      - '745'
+      - '767'
       Access-Control-Allow-Origin:
       - "*"
+      Connection:
+      - close
     body:
       encoding: UTF-8
-      string: <soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope"><soap:Body><ns2:AuthenticateResponse
-        xmlns:ns2="http://www.exchangenetwork.net/wsdl/register/auth/1"><User><firstName>Brandon</firstName><governmentPartner>false</governmentPartner><lastLogin>2016-01-20T13:30:52-05:00</lastLogin><lastName>Kirby</lastName><lexisNexisAttempts>0</lexisNexisAttempts><passwordResetAttempts>0</passwordResetAttempts><registrationDate>2015-08-21T16:11:14-04:00</registrationDate><status>Valid</status><title><description>Mr</description></title><userId>18F_CERTIFIER</userId><verificationIndexElectronic>0</verificationIndexElectronic><verificationIndexPaper>700</verificationIndexPaper></User></ns2:AuthenticateResponse></soap:Body></soap:Envelope>
+      string: <soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope"><soap:Body><soap:Fault><soap:Code><soap:Value>soap:Receiver</soap:Value></soap:Code><soap:Reason><soap:Text
+        xml:lang="en">Fault occurred while processing.</soap:Text></soap:Reason><soap:Detail><ns1:RegisterAuthFault
+        xmlns:ns1="http://www.exchangenetwork.net/wsdl/register/auth/1"><description
+        xmlns:ns2="http://www.exchangenetwork.net/wsdl/register/auth/1">Unable to
+        authenticate user - The password is invalid.</description><errorCode xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:ns2="http://www.exchangenetwork.net/wsdl/register/auth/1" xsi:type="ns2:RegisterAuthErrorCode">E_WrongIdPassword</errorCode></ns1:RegisterAuthFault></soap:Detail></soap:Fault></soap:Body></soap:Envelope>
     http_version: 
-  recorded_at: Wed, 20 Jan 2016 18:31:28 GMT
-- request:
-    method: post
-    uri: https://devngn.epacdxnode.net/cdx-register-II/services/RegisterSignService
-    body:
-      encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tns="http://www.exchangenetwork.net/wsdl/register/sign/1"
-        xmlns:env="http://www.w3.org/2003/05/soap-envelope"><env:Body><tns:CreateActivityWithProperties><securityToken>fakeSecurityToken</securityToken><signatureUser><UserId>18F_CERTIFIER</UserId><FirstName>Brandon</FirstName><LastName>Kirby</LastName><MiddleInitial
-        xsi:nil="true"/></signatureUser><dataflowName>eManifest</dataflowName><properties><Property><Key>activityDescription</Key><Value>development
-        test</Value></Property></properties><properties><Property><Key>roleCode</Key><Value>112090</Value></Property></properties></tns:CreateActivityWithProperties></env:Body></env:Envelope>
-    headers:
-      Soapaction:
-      - '"CreateActivityWithProperties"'
-      Content-Type:
-      - application/soap+xml;charset=UTF-8
-      Content-Length:
-      - '1006'
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 20 Jan 2016 18:30:52 GMT
-      Server:
-      - Apache-Coyote/1.1
-      X-Frame-Options:
-      - SAMEORIGIN, SAMEORIGIN
-      Content-Type:
-      - multipart/related; type="application/xop+xml"; boundary="uuid:4e585b76-d4bf-4829-8662-4a795eb8bcc7";
-        start="<root.message@cxf.apache.org>"; start-info="application/soap+xml"
-      Content-Length:
-      - '570'
-      Access-Control-Allow-Origin:
-      - "*"
-    body:
-      encoding: UTF-8
-      string: "--uuid:4e585b76-d4bf-4829-8662-4a795eb8bcc7\r\nContent-Type: application/xop+xml;
-        charset=UTF-8; type=\"application/soap+xml\";\r\nContent-Transfer-Encoding:
-        binary\r\nContent-ID: <root.message@cxf.apache.org>\r\n\r\n<soap:Envelope
-        xmlns:soap=\"http://www.w3.org/2003/05/soap-envelope\"><soap:Body><ns2:CreateActivityWithPropertiesResponse
-        xmlns:ns2=\"http://www.exchangenetwork.net/wsdl/register/sign/1\"><activityId>_10b773da-0f11-45e2-af65-ffa61b3f9f2c</activityId></ns2:CreateActivityWithPropertiesResponse></soap:Body></soap:Envelope>\r\n--uuid:4e585b76-d4bf-4829-8662-4a795eb8bcc7--"
-    http_version: 
-  recorded_at: Wed, 20 Jan 2016 18:31:28 GMT
-- request:
-    method: post
-    uri: https://devngn.epacdxnode.net/cdx-register-II/services/RegisterSignService
-    body:
-      encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tns="http://www.exchangenetwork.net/wsdl/register/sign/1"
-        xmlns:env="http://www.w3.org/2003/05/soap-envelope"><env:Body><tns:GetQuestion><securityToken>fakeSecurityToken</securityToken><activityId>_10b773da-0f11-45e2-af65-ffa61b3f9f2c</activityId><userId>18F_CERTIFIER</userId></tns:GetQuestion></env:Body></env:Envelope>
-    headers:
-      Soapaction:
-      - '"GetQuestion"'
-      Content-Type:
-      - application/soap+xml;charset=UTF-8
-      Content-Length:
-      - '685'
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 20 Jan 2016 18:30:52 GMT
-      Server:
-      - Apache-Coyote/1.1
-      X-Frame-Options:
-      - SAMEORIGIN, SAMEORIGIN
-      Content-Type:
-      - multipart/related; type="application/xop+xml"; boundary="uuid:e6c63aec-9ae2-4c51-9259-26d7329e5bb5";
-        start="<root.message@cxf.apache.org>"; start-info="application/soap+xml"
-      Content-Length:
-      - '591'
-      Access-Control-Allow-Origin:
-      - "*"
-    body:
-      encoding: UTF-8
-      string: "--uuid:e6c63aec-9ae2-4c51-9259-26d7329e5bb5\r\nContent-Type: application/xop+xml;
-        charset=UTF-8; type=\"application/soap+xml\";\r\nContent-Transfer-Encoding:
-        binary\r\nContent-ID: <root.message@cxf.apache.org>\r\n\r\n<soap:Envelope
-        xmlns:soap=\"http://www.w3.org/2003/05/soap-envelope\"><soap:Body><ns2:GetQuestionResponse
-        xmlns:ns2=\"http://www.exchangenetwork.net/wsdl/register/sign/1\"><question><questionId>1</questionId><text>What
-        is the first and middle name of your oldest sibling?</text></question></ns2:GetQuestionResponse></soap:Body></soap:Envelope>\r\n--uuid:e6c63aec-9ae2-4c51-9259-26d7329e5bb5--"
-    http_version: 
-  recorded_at: Wed, 20 Jan 2016 18:31:28 GMT
+  recorded_at: Thu, 21 Jan 2016 00:43:25 GMT
 recorded_with: VCR 3.0.1

--- a/spec/support/fixtures/vcr_cassettes/create_authenticator_with_wrong_user_id.yml
+++ b/spec/support/fixtures/vcr_cassettes/create_authenticator_with_wrong_user_id.yml
@@ -19,7 +19,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 20 Jan 2016 18:30:50 GMT
+      - Thu, 21 Jan 2016 00:41:47 GMT
       Server:
       - Apache-Coyote/1.1
       X-Frame-Options:
@@ -708,7 +708,7 @@ http_interactions:
           </wsdl:service>
         </wsdl:definitions>
     http_version: 
-  recorded_at: Wed, 20 Jan 2016 18:31:26 GMT
+  recorded_at: Thu, 21 Jan 2016 00:42:23 GMT
 - request:
     method: post
     uri: https://devngn.epacdxnode.net/cdx-register-II/services/RegisterSignService
@@ -736,13 +736,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 20 Jan 2016 18:30:50 GMT
+      - Thu, 21 Jan 2016 00:41:47 GMT
       Server:
       - Apache-Coyote/1.1
       X-Frame-Options:
       - SAMEORIGIN, SAMEORIGIN
       Content-Type:
-      - multipart/related; type="application/xop+xml"; boundary="uuid:f10ec302-33bd-4cc5-a255-1325e4c816a1";
+      - multipart/related; type="application/xop+xml"; boundary="uuid:8d038e67-bfe8-4429-912f-3de1b17da052";
         start="<root.message@cxf.apache.org>"; start-info="application/soap+xml"
       Content-Length:
       - '731'
@@ -750,13 +750,13 @@ http_interactions:
       - "*"
     body:
       encoding: UTF-8
-      string: "--uuid:f10ec302-33bd-4cc5-a255-1325e4c816a1\r\nContent-Type: application/xop+xml;
+      string: "--uuid:8d038e67-bfe8-4429-912f-3de1b17da052\r\nContent-Type: application/xop+xml;
         charset=UTF-8; type=\"application/soap+xml\";\r\nContent-Transfer-Encoding:
         binary\r\nContent-ID: <root.message@cxf.apache.org>\r\n\r\n<soap:Envelope
         xmlns:soap=\"http://www.w3.org/2003/05/soap-envelope\"><soap:Body><ns2:AuthenticateResponse
-        xmlns:ns2=\"http://www.exchangenetwork.net/wsdl/register/sign/1\"><securityToken>fakeSecurityToken</securityToken></ns2:AuthenticateResponse></soap:Body></soap:Envelope>\r\n--uuid:f10ec302-33bd-4cc5-a255-1325e4c816a1--"
+        xmlns:ns2=\"http://www.exchangenetwork.net/wsdl/register/sign/1\"><securityToken>csm:IiKaBeCRDqLQCDSlyPFQ5L2Wh58w_dbWJ6Vv1CCqcOgJH-GgGOBnI1P3PlH4UTzq.5zSAx_QQQqT042Z7Uhro_dW9mNLtYcbR5BFL3382XXS5e_TzviVG3OHFLt-yoNYx.Hm_OGCWOpkLW7quPpdXA6BYScxUIpnMFvc-MC_-xLFrpOx2dCYITza4dcGdncLDw.3kAwFQVG-Dld_VwLR4O8ug,,.</securityToken></ns2:AuthenticateResponse></soap:Body></soap:Envelope>\r\n--uuid:8d038e67-bfe8-4429-912f-3de1b17da052--"
     http_version: 
-  recorded_at: Wed, 20 Jan 2016 18:31:26 GMT
+  recorded_at: Thu, 21 Jan 2016 00:42:24 GMT
 - request:
     method: get
     uri: https://devngn.epacdxnode.net/cdx-register/services/RegisterAuthService?wsdl
@@ -776,7 +776,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 20 Jan 2016 18:30:51 GMT
+      - Thu, 21 Jan 2016 00:41:48 GMT
       Server:
       - Apache-Coyote/1.1
       X-Frame-Options:
@@ -898,7 +898,7 @@ http_interactions:
           </wsdl:service>
         </wsdl:definitions>
     http_version: 
-  recorded_at: Wed, 20 Jan 2016 18:31:27 GMT
+  recorded_at: Thu, 21 Jan 2016 00:42:24 GMT
 - request:
     method: post
     uri: https://devngn.epacdxnode.net/cdx-register-II/services/RegisterAuthService
@@ -906,14 +906,14 @@ http_interactions:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tns="http://www.exchangenetwork.net/wsdl/register/auth/1"
-        xmlns:env="http://www.w3.org/2003/05/soap-envelope"><env:Body><tns:Authenticate><userId>18f_certifier</userId><password>k84jf9sh2fa3nM5</password></tns:Authenticate></env:Body></env:Envelope>
+        xmlns:env="http://www.w3.org/2003/05/soap-envelope"><env:Body><tns:Authenticate><userId>wrong</userId><password>wrong</password></tns:Authenticate></env:Body></env:Envelope>
     headers:
       Soapaction:
       - '"Authenticate"'
       Content-Type:
       - application/soap+xml;charset=UTF-8
       Content-Length:
-      - '406'
+      - '388'
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -922,11 +922,11 @@ http_interactions:
       - Ruby
   response:
     status:
-      code: 200
-      message: OK
+      code: 500
+      message: Internal Server Error
     headers:
       Date:
-      - Wed, 20 Jan 2016 18:30:51 GMT
+      - Thu, 21 Jan 2016 00:41:48 GMT
       Server:
       - Apache-Coyote/1.1
       X-Frame-Options:
@@ -934,112 +934,19 @@ http_interactions:
       Content-Type:
       - application/soap+xml;charset=UTF-8
       Content-Length:
-      - '745'
+      - '738'
       Access-Control-Allow-Origin:
       - "*"
+      Connection:
+      - close
     body:
       encoding: UTF-8
-      string: <soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope"><soap:Body><ns2:AuthenticateResponse
-        xmlns:ns2="http://www.exchangenetwork.net/wsdl/register/auth/1"><User><firstName>Brandon</firstName><governmentPartner>false</governmentPartner><lastLogin>2016-01-20T13:30:52-05:00</lastLogin><lastName>Kirby</lastName><lexisNexisAttempts>0</lexisNexisAttempts><passwordResetAttempts>0</passwordResetAttempts><registrationDate>2015-08-21T16:11:14-04:00</registrationDate><status>Valid</status><title><description>Mr</description></title><userId>18F_CERTIFIER</userId><verificationIndexElectronic>0</verificationIndexElectronic><verificationIndexPaper>700</verificationIndexPaper></User></ns2:AuthenticateResponse></soap:Body></soap:Envelope>
+      string: <soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope"><soap:Body><soap:Fault><soap:Code><soap:Value>soap:Receiver</soap:Value></soap:Code><soap:Reason><soap:Text
+        xml:lang="en">Fault occurred while processing.</soap:Text></soap:Reason><soap:Detail><ns1:RegisterAuthFault
+        xmlns:ns1="http://www.exchangenetwork.net/wsdl/register/auth/1"><description
+        xmlns:ns2="http://www.exchangenetwork.net/wsdl/register/auth/1">user WRONG
+        does not exist</description><errorCode xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:ns2="http://www.exchangenetwork.net/wsdl/register/auth/1" xsi:type="ns2:RegisterAuthErrorCode">E_WrongIdPassword</errorCode></ns1:RegisterAuthFault></soap:Detail></soap:Fault></soap:Body></soap:Envelope>
     http_version: 
-  recorded_at: Wed, 20 Jan 2016 18:31:28 GMT
-- request:
-    method: post
-    uri: https://devngn.epacdxnode.net/cdx-register-II/services/RegisterSignService
-    body:
-      encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tns="http://www.exchangenetwork.net/wsdl/register/sign/1"
-        xmlns:env="http://www.w3.org/2003/05/soap-envelope"><env:Body><tns:CreateActivityWithProperties><securityToken>fakeSecurityToken</securityToken><signatureUser><UserId>18F_CERTIFIER</UserId><FirstName>Brandon</FirstName><LastName>Kirby</LastName><MiddleInitial
-        xsi:nil="true"/></signatureUser><dataflowName>eManifest</dataflowName><properties><Property><Key>activityDescription</Key><Value>development
-        test</Value></Property></properties><properties><Property><Key>roleCode</Key><Value>112090</Value></Property></properties></tns:CreateActivityWithProperties></env:Body></env:Envelope>
-    headers:
-      Soapaction:
-      - '"CreateActivityWithProperties"'
-      Content-Type:
-      - application/soap+xml;charset=UTF-8
-      Content-Length:
-      - '1006'
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 20 Jan 2016 18:30:52 GMT
-      Server:
-      - Apache-Coyote/1.1
-      X-Frame-Options:
-      - SAMEORIGIN, SAMEORIGIN
-      Content-Type:
-      - multipart/related; type="application/xop+xml"; boundary="uuid:4e585b76-d4bf-4829-8662-4a795eb8bcc7";
-        start="<root.message@cxf.apache.org>"; start-info="application/soap+xml"
-      Content-Length:
-      - '570'
-      Access-Control-Allow-Origin:
-      - "*"
-    body:
-      encoding: UTF-8
-      string: "--uuid:4e585b76-d4bf-4829-8662-4a795eb8bcc7\r\nContent-Type: application/xop+xml;
-        charset=UTF-8; type=\"application/soap+xml\";\r\nContent-Transfer-Encoding:
-        binary\r\nContent-ID: <root.message@cxf.apache.org>\r\n\r\n<soap:Envelope
-        xmlns:soap=\"http://www.w3.org/2003/05/soap-envelope\"><soap:Body><ns2:CreateActivityWithPropertiesResponse
-        xmlns:ns2=\"http://www.exchangenetwork.net/wsdl/register/sign/1\"><activityId>_10b773da-0f11-45e2-af65-ffa61b3f9f2c</activityId></ns2:CreateActivityWithPropertiesResponse></soap:Body></soap:Envelope>\r\n--uuid:4e585b76-d4bf-4829-8662-4a795eb8bcc7--"
-    http_version: 
-  recorded_at: Wed, 20 Jan 2016 18:31:28 GMT
-- request:
-    method: post
-    uri: https://devngn.epacdxnode.net/cdx-register-II/services/RegisterSignService
-    body:
-      encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tns="http://www.exchangenetwork.net/wsdl/register/sign/1"
-        xmlns:env="http://www.w3.org/2003/05/soap-envelope"><env:Body><tns:GetQuestion><securityToken>fakeSecurityToken</securityToken><activityId>_10b773da-0f11-45e2-af65-ffa61b3f9f2c</activityId><userId>18F_CERTIFIER</userId></tns:GetQuestion></env:Body></env:Envelope>
-    headers:
-      Soapaction:
-      - '"GetQuestion"'
-      Content-Type:
-      - application/soap+xml;charset=UTF-8
-      Content-Length:
-      - '685'
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 20 Jan 2016 18:30:52 GMT
-      Server:
-      - Apache-Coyote/1.1
-      X-Frame-Options:
-      - SAMEORIGIN, SAMEORIGIN
-      Content-Type:
-      - multipart/related; type="application/xop+xml"; boundary="uuid:e6c63aec-9ae2-4c51-9259-26d7329e5bb5";
-        start="<root.message@cxf.apache.org>"; start-info="application/soap+xml"
-      Content-Length:
-      - '591'
-      Access-Control-Allow-Origin:
-      - "*"
-    body:
-      encoding: UTF-8
-      string: "--uuid:e6c63aec-9ae2-4c51-9259-26d7329e5bb5\r\nContent-Type: application/xop+xml;
-        charset=UTF-8; type=\"application/soap+xml\";\r\nContent-Transfer-Encoding:
-        binary\r\nContent-ID: <root.message@cxf.apache.org>\r\n\r\n<soap:Envelope
-        xmlns:soap=\"http://www.w3.org/2003/05/soap-envelope\"><soap:Body><ns2:GetQuestionResponse
-        xmlns:ns2=\"http://www.exchangenetwork.net/wsdl/register/sign/1\"><question><questionId>1</questionId><text>What
-        is the first and middle name of your oldest sibling?</text></question></ns2:GetQuestionResponse></soap:Body></soap:Envelope>\r\n--uuid:e6c63aec-9ae2-4c51-9259-26d7329e5bb5--"
-    http_version: 
-  recorded_at: Wed, 20 Jan 2016 18:31:28 GMT
+  recorded_at: Thu, 21 Jan 2016 00:42:25 GMT
 recorded_with: VCR 3.0.1


### PR DESCRIPTION
- Consistently use new hash syntax and symbols for hash keys
- Do not use aliased methods (hard to grep for)
