### PR TITLE
Wrap views in usa grid classes

### DIFF
--- a/app/views/manifest_uploads/new.html.erb
+++ b/app/views/manifest_uploads/new.html.erb
@@ -1,9 +1,13 @@
-<h3>Attach a scan of the manifest</h3>
+<div class="usa-width-one-whole">
 
-<%= simple_form_for :manifest, url: upload_path, method: :post do |form| %>
-  <%= form.input :uploaded_file, as: :file %>
-  <%= form.simple_fields_for :generator do |generator| %>
-    <%= generator.input :manifest_tracking_number, label: 'Manifest Tracking Number' %>
+  <h3>Attach a scan of the manifest</h3>
+
+  <%= simple_form_for :manifest, url: upload_path, method: :post do |form| %>
+    <%= form.input :uploaded_file, as: :file %>
+    <%= form.simple_fields_for :generator do |generator| %>
+      <%= generator.input :manifest_tracking_number, label: 'Manifest Tracking Number' %>
+    <% end %>
+    <%= form.submit 'Submit' %>
   <% end %>
-  <%= form.submit 'Submit' %>
-<% end %>
+
+</div>

--- a/app/views/manifests/new.html.erb
+++ b/app/views/manifests/new.html.erb
@@ -1,42 +1,46 @@
-<h3>Submit new manifest</h3>
+<div class="usa-width-one-whole">
 
-<%= simple_form_for :manifest, url: manifests_path, method: :post do |form| %>
-  <h3>Generator</h3>
-  <%= form.simple_fields_for :generator do |generator| %>
-    <%= generator.input :us_epa_id_number, label: 'U.S. EPA ID Number (1)' %>
-    <%= generator.input :emergency_response_phone, label: 'Emergency Response Phone (3)' %>
-    <%= generator.input :manifest_tracking_number, label: 'Manifest Tracking Number (4)' %>
-    <%= generator.input :name, label: 'Name (5)' %>
+  <h3>Submit new manifest</h3>
 
-    <h3>Mailing address</h3>
-    <%= render partial: 'address', locals: { object: generator, number: 5 } %>
+  <%= simple_form_for :manifest, url: manifests_path, method: :post do |form| %>
+    <h3>Generator</h3>
+    <%= form.simple_fields_for :generator do |generator| %>
+      <%= generator.input :us_epa_id_number, label: 'U.S. EPA ID Number (1)' %>
+      <%= generator.input :emergency_response_phone, label: 'Emergency Response Phone (3)' %>
+      <%= generator.input :manifest_tracking_number, label: 'Manifest Tracking Number (4)' %>
+      <%= generator.input :name, label: 'Name (5)' %>
 
-    <%= generator.input :phone_number, label: 'Phone number (5)' %>
+      <h3>Mailing address</h3>
+      <%= render partial: 'address', locals: { object: generator, number: 5 } %>
+
+      <%= generator.input :phone_number, label: 'Phone number (5)' %>
+    <% end %>
+
+    <h3>Transporter 1</h3>
+    <div class="transporter-1">
+      <%= simple_fields_for :transporter_1 do |transporter| %>
+        <%= transporter.input :name, label: 'Company Name (6)' %>
+        <%= transporter.input :us_epa_id_number, label: 'U.S. EPA ID Number (6)' %>
+      <% end %>
+    </div>
+
+    <h3>Transporter 2</h3>
+    <div class="transporter-2">
+      <%= simple_fields_for :transporter_2 do |transporter| %>
+        <%= transporter.input :name, label: 'Company Name (6)' %>
+        <%= transporter.input :us_epa_id_number, label: 'U.S. EPA ID Number (6)' %>
+      <% end %>
+    <div>
+
+    <h3>Designated Facility</h3>
+    <%= simple_fields_for :designated_facility do |facility| %>
+      <%= facility.input :name, label: 'Name (8)' %>
+      <%= render partial: 'address', locals: { object: facility, number: 8 } %>
+      <%= facility.input :phone_number, label: 'Phone number (8)' %>
+      <%= facility.input :us_epa_id_number, label: 'U.S. EPA ID Number (8)' %>
+    <% end %>
+
+    <%= form.submit 'Continue' %>
   <% end %>
 
-  <h3>Transporter 1</h3>
-  <div class="transporter-1">
-    <%= simple_fields_for :transporter_1 do |transporter| %>
-      <%= transporter.input :name, label: 'Company Name (6)' %>
-      <%= transporter.input :us_epa_id_number, label: 'U.S. EPA ID Number (6)' %>
-    <% end %>
-  </div>
-
-  <h3>Transporter 2</h3>
-  <div class="transporter-2">
-    <%= simple_fields_for :transporter_2 do |transporter| %>
-      <%= transporter.input :name, label: 'Company Name (6)' %>
-      <%= transporter.input :us_epa_id_number, label: 'U.S. EPA ID Number (6)' %>
-    <% end %>
-  <div>
-
-  <h3>Designated Facility</h3>
-  <%= simple_fields_for :designated_facility do |facility| %>
-    <%= facility.input :name, label: 'Name (8)' %>
-    <%= render partial: 'address', locals: { object: facility, number: 8 } %>
-    <%= facility.input :phone_number, label: 'Phone number (8)' %>
-    <%= facility.input :us_epa_id_number, label: 'U.S. EPA ID Number (8)' %>
-  <% end %>
-
-  <%= form.submit 'Continue' %>
-<% end %>
+</div>

--- a/app/views/sign_or_upload/new.html.erb
+++ b/app/views/sign_or_upload/new.html.erb
@@ -1,9 +1,13 @@
-<h3>Sign or Upload</h3>
+<div class="usa-width-one-whole">
 
-<p>
-  Would you like to electronically sign this manifest (CDX login required) or
-  would you like to upload a scan of the original manifest?
-</p>
+  <h3>Sign or Upload</h3>
 
-<%= link_to 'Sign', new_manifest_token_path(@manifest) %>
-<%= link_to 'Upload', new_manifest_manifest_upload_path(@manifest) %>
+  <p>
+    Would you like to electronically sign this manifest (CDX login required) or
+    would you like to upload a scan of the original manifest?
+  </p>
+
+  <%= link_to 'Sign', new_manifest_token_path(@manifest) %>
+  <%= link_to 'Upload', new_manifest_manifest_upload_path(@manifest) %>
+
+</div>

--- a/app/views/signatures/new.html.erb
+++ b/app/views/signatures/new.html.erb
@@ -1,1 +1,5 @@
-What is your favorite hobby?
+<div class="usa-width-one-whole">
+
+  What is your favorite hobby?
+
+</div>

--- a/app/views/submissions/new.html.erb
+++ b/app/views/submissions/new.html.erb
@@ -1,4 +1,8 @@
-<h3>Submit a manifest</h3>
+<div class="usa-width-one-whole">
 
-<%= link_to 'Submit via form', new_manifest_path, :class => 'usa-button' %>
-<%= link_to 'Upload scan', new_manifest_upload_path,  :class => 'usa-button usa-button-outline' %>
+  <h3>Submit a manifest</h3>
+
+  <%= link_to 'Submit via form', new_manifest_path, :class => 'usa-button' %>
+  <%= link_to 'Upload scan', new_manifest_upload_path,  :class => 'usa-button usa-button-outline' %>
+  
+</div>

--- a/app/views/tokens/new.html.erb
+++ b/app/views/tokens/new.html.erb
@@ -1,5 +1,9 @@
-<%= simple_form_for :token, url: manifest_tokens_path(@manifest), method: :post do |form| %>
-  <%= form.input :user_id, label: 'Username' %>
-  <%= form.input :password, label: 'Password' %>
-  <%= form.submit 'Login' %>
-<% end %>
+<div class="usa-width-one-whole">
+
+  <%= simple_form_for :token, url: manifest_tokens_path(@manifest), method: :post do |form| %>
+    <%= form.input :user_id, label: 'Username' %>
+    <%= form.input :password, label: 'Password' %>
+    <%= form.submit 'Login' %>
+  <% end %>
+
+</div>


### PR DESCRIPTION
To prevent a small gap of blue between the main content and the nav content we need to wrap the views in the `usa-width-*` classes. We can’t do this at the `application.html.erb` level because we need the views to be able to configure themselves as two-thirds/one-third or full width. For example, the index search view has a right hand section for the search query form.

Blue gap example:
![Example of blue gap between nav and content](https://cloud.githubusercontent.com/assets/601515/12436479/8bf90032-beca-11e5-81e8-331f9592cdc3.png)

PR changes:
![Changes to UI with PR, no blue gap](https://s3.amazonaws.com/f.cl.ly/items/1n1f2y412y3L0r162j0l/Screen%20Shot%202016-01-20%20at%202.49.26%20PM.png?v=cfe216ea)
