### PR TITLE
Embed swagger docs in application layout

### DIFF
--- a/app/assets/stylesheets/_reset.scss
+++ b/app/assets/stylesheets/_reset.scss
@@ -1,0 +1,24 @@
+.swagger-section form {
+  max-width: 100%;
+}
+
+.swagger-section ul:not(.options) {
+  width: 100%;
+}
+
+.swagger-section ul li:before {
+  content: '';
+  display: none;
+}
+
+.swagger-section .endpoints {
+  margin-bottom: 0;
+}
+
+.swagger-section .operations {
+  margin: 0;
+}
+
+.swagger-section .toggleOperation {
+  margin: .3em;
+}

--- a/app/assets/stylesheets/_swagger.scss
+++ b/app/assets/stylesheets/_swagger.scss
@@ -2,6 +2,11 @@
   max-width: 100%;
 }
 
+.swagger-section ul,
+.swagger-section ol {
+  list-style-type: none;
+}
+
 .swagger-section ul:not(.options) {
   width: 100%;
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,11 +1,14 @@
 @charset "utf-8";
 
 /*
+
  * = require us_web_design_standards
  * = require us_web_design_standards_fonts
+ * = require swagger-ui/screen
  */
 
  @import "variables";
+ @import "reset";
 
  @import "callout";
  @import "disclaimer";
@@ -25,3 +28,8 @@
  main {
    background-color: $base-background-color;
  }
+
+.swagger-section ul,
+.swagger-section ol {
+  list-style-type: none;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -8,7 +8,6 @@
  */
 
  @import "variables";
- @import "reset";
 
  @import "callout";
  @import "disclaimer";
@@ -16,6 +15,7 @@
  @import "headings";
  @import "lists";
  @import "nav";
+ @import "swagger";
  @import "tables";
  @import "text";
 
@@ -28,8 +28,3 @@
  main {
    background-color: $base-background-color;
  }
-
-.swagger-section ul,
-.swagger-section ol {
-  list-style-type: none;
-}

--- a/app/controllers/api_documentation_controller.rb
+++ b/app/controllers/api_documentation_controller.rb
@@ -4,6 +4,6 @@ class ApiDocumentationController < ApplicationController
   end
 
   def swagger
-    render 'api-docs/swagger/index', layout: false
+    render 'api-docs/swagger/index'
   end
 end

--- a/app/views/api-docs/examples/index.html.md
+++ b/app/views/api-docs/examples/index.html.md
@@ -198,4 +198,3 @@ The response will look like:
   // more methods here
 ]
 ```
-

--- a/app/views/api-docs/swagger/index.html.erb
+++ b/app/views/api-docs/swagger/index.html.erb
@@ -1,24 +1,5 @@
-<!DOCTYPE html>
-<html>
-<head>
-  <meta charset="utf-8" />
-  <meta name="ROBOTS" content="NOODP" />
-  <meta name="viewport" content="initial-scale=1" />
-  <title>e-Manifest API Documentation</title>
-  <%= stylesheet_link_tag 'swagger-ui' %>
-  <%= csrf_meta_tags %>
-</head>
-<body class="swagger-section">
-  <header>
-    <div class='container'>
-      <div>
-        <h1>e-Manifest</h1>
-        <%= link_to 'Home', root_path %>
-        <%= link_to 'Industry', new_submission_path %>
-      </div>
-    </div>
-  </header>
-<%= render "javascript" %>
-<%= render 'swagger_ui/swagger_ui', discovery_url: 'swagger.json' %>
-</body>
-</html>
+<%= stylesheet_link_tag 'swagger-ui/screen' %>
+<div class="swagger-section usa-width-one-whole">
+  <%= render "javascript" %>
+  <%= render 'swagger_ui/swagger_ui', discovery_url: 'swagger.json' %>
+</div>

--- a/app/views/api-docs/swagger/index.html.erb
+++ b/app/views/api-docs/swagger/index.html.erb
@@ -1,5 +1,3 @@
-<%= stylesheet_link_tag 'swagger-ui/screen' %>
 <div class="swagger-section usa-width-one-whole">
-  <%= render "javascript" %>
   <%= render 'swagger_ui/swagger_ui', discovery_url: 'swagger.json' %>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,6 +15,8 @@
   <%= render "analytics" %>
 </head>
 <body>
+  <%# js loaded at the top for ensuring dependencies are loaded %>
+  <%= render "javascript" %>
   <%= render "disclaimer" %>
   <nav>
     <div class="usa-grid">
@@ -42,7 +44,5 @@
   <main class="usa-grid">
     <%= yield %>
   </main>
-
-  <%= render "javascript" %>
 </body>
 </html>


### PR DESCRIPTION
To keep the UI of the site consistent, the swagger docs are now using the application layout and are thus displayed in the same interface as the rest of the web application.
