### PR TITLE
Signing token date

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,6 @@ services:
   - postgresql
   - elasticsearch
   - redis
+env:
+  - RACK_ENV=test
+  - RAILS_ENV=test

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,4 @@ addons:
 services:
   - postgresql
   - elasticsearch
+  - redis

--- a/app/controllers/api/v0/signatures_controller.rb
+++ b/app/controllers/api/v0/signatures_controller.rb
@@ -35,7 +35,7 @@ class Api::V0::SignaturesController < ApiController
     if cdx_response.key?(:document_id)
       manifest.document_id = cdx_response[:document_id]
       manifest.activity_id = signature_request[:activity_id]
-      manifest.signed_at = Time.now
+      manifest.signed_at = Time.current
       manifest.save!
       status = 200
     else

--- a/app/controllers/api/v0/tokens_controller.rb
+++ b/app/controllers/api/v0/tokens_controller.rb
@@ -19,6 +19,8 @@ class Api::V0::TokensController < ApiController
     end
   end
 
+  private
+
   def store_signature_token(cdx_token)
     user_token = SecureRandom.uuid
     redis = Redis.new

--- a/app/controllers/api/v0/tokens_controller.rb
+++ b/app/controllers/api/v0/tokens_controller.rb
@@ -8,7 +8,8 @@ class Api::V0::TokensController < ApiController
     Rails.logger.debug(ANSI.blue{ "  CDX authenticator time: #{sprintf('%#g', (cdx_stop - cdx_start))} seconds" })
 
     if response[:token]
-      response[:token] = Base64.strict_encode64(response[:token])
+      user_token = store_signature_token(response[:token])
+      response[:token] = user_token
       render json: response.to_json, status: 200
     else
       render json: {
@@ -16,5 +17,12 @@ class Api::V0::TokensController < ApiController
         errors: response[:description]
       }.to_json, status: 401
     end
+  end
+
+  def store_signature_token(cdx_token)
+    user_token = SecureRandom.uuid
+    redis = Redis.new
+    redis.set(user_token, cdx_token)
+    user_token
   end
 end

--- a/db/migrate/20160125160835_add_signed_at.rb
+++ b/db/migrate/20160125160835_add_signed_at.rb
@@ -1,0 +1,9 @@
+class AddSignedAt < ActiveRecord::Migration
+  def up
+    add_column :manifests, :signed_at, :datetime
+  end
+
+  def down
+    remove_column :manifests, :signed_at
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -54,7 +54,8 @@ CREATE TABLE manifests (
     updated_at timestamp without time zone NOT NULL,
     activity_id character varying,
     document_id character varying,
-    uuid uuid DEFAULT uuid_generate_v4()
+    uuid uuid DEFAULT uuid_generate_v4(),
+    signed_at timestamp without time zone
 );
 
 
@@ -138,7 +139,11 @@ INSERT INTO schema_migrations (version) VALUES ('20160112190459');
 
 INSERT INTO schema_migrations (version) VALUES ('20160115181255');
 
+INSERT INTO schema_migrations (version) VALUES ('20160115203719');
+
 INSERT INTO schema_migrations (version) VALUES ('20160115204128');
 
 INSERT INTO schema_migrations (version) VALUES ('20160120171331');
+
+INSERT INTO schema_migrations (version) VALUES ('20160125160835');
 

--- a/spec/requests/api/v0/post_tokens_spec.rb
+++ b/spec/requests/api/v0/post_tokens_spec.rb
@@ -29,6 +29,7 @@ describe 'POST /api/v0/tokens' do
 
       expect(response.status).to eq(200)
       expect(parsed_response['token']).not_to be_nil
+      expect(Redis.new.get(parsed_response['token'])).to_not be_nil
      end
   end
 

--- a/spec/requests/api_spec.rb
+++ b/spec/requests/api_spec.rb
@@ -15,6 +15,7 @@ describe 'API request spec' do
         manifest.reload
         expect(manifest.document_id).to eq('44')
         expect(manifest.activity_id).to eq('22')
+        expect(manifest.signed_at).to_not eq(nil)
       end
 
       it 'will not update the document/activity id if the CDX request does not include the right key' do
@@ -29,6 +30,7 @@ describe 'API request spec' do
         manifest.reload
         expect(manifest.document_id).to eq(nil)
         expect(manifest.activity_id).to eq(nil)
+        expect(manifest.signed_at).to eq(nil)
       end
     end
 
@@ -53,6 +55,7 @@ describe 'API request spec' do
         manifest.reload
         expect(manifest.document_id).to eq('44')
         expect(manifest.activity_id).to eq('22')
+        expect(manifest.signed_at).to_not eq(nil)
       end
     end
   end


### PR DESCRIPTION
This PR does 2 things:
- CDX signature token is stored server-side in Redis and referenced by a random uuid, which is what is passed on in our _token_ response. This is because CDX returns a single token for all e-manifest requests. Previously this was done with a session id but sessions in Rails are stored in cookies; using Redis lets us scale our web servers as well.
- Stores the signature datetime on the manifest itself. This makes explicit when the manifest was signed, which avoids the case where the manifest is updated after being signed and we can therefore no longer rely on the `updated_at` value.

This PR is branched off of #101 and should be merged after that PR is merged.
