### PR TITLE
Add helpful error messages for web when invalid manifest

### DIFF
--- a/app/controllers/manifests_controller.rb
+++ b/app/controllers/manifests_controller.rb
@@ -5,17 +5,16 @@ class ManifestsController < ApplicationController
   end
 
   def create
-    if validate_manifest(manifest_params)
-      @manifest = Manifest.new(content: manifest_params)
+    @manifest = Manifest.new(content: manifest_params)
 
-      if @manifest.save!
-        @manifest.reload
-        tracking_number = @manifest.tracking_number
-        flash[:notice] = "Manifest #{tracking_number} submitted successfully."
-        redirect_to new_manifest_sign_or_upload_path(@manifest.uuid)
-      end
+    if @manifest.save && validate_manifest(manifest_params)
+      @manifest.reload
+      tracking_number = @manifest.tracking_number
+      flash[:notice] = "Manifest #{tracking_number} submitted successfully."
+      redirect_to new_manifest_sign_or_upload_path(@manifest.uuid)
     else
-      render 'new'
+      flash[:error] = @manifest.errors.full_messages.to_sentence
+      render :new
     end
   end
 

--- a/app/controllers/manifests_controller.rb
+++ b/app/controllers/manifests_controller.rb
@@ -13,7 +13,7 @@ class ManifestsController < ApplicationController
       flash[:notice] = "Manifest #{tracking_number} submitted successfully."
       redirect_to new_manifest_sign_or_upload_path(@manifest.uuid)
     else
-      flash[:error] = @manifest.errors.full_messages.to_sentence
+      flash[:error] = @errors || @manifest.errors.full_messages.to_sentence
       render :new
     end
   end
@@ -38,7 +38,7 @@ class ManifestsController < ApplicationController
   def validate_manifest(content)
     validator = ManifestValidator.new(content)
     unless validator.run
-      @errors = validator.error_messages
+      @errors = validator.errors
     end
     !validator.errors.any?
   end

--- a/app/models/manifest.rb
+++ b/app/models/manifest.rb
@@ -97,6 +97,8 @@ class Manifest < ActiveRecord::Base
   def validate_tracking_number_unique
     if tracking_number.blank?
       errors.add(:tracking_number, "must be present")
+    elsif tracking_number !~ /^[0-9]{9}[A-Za-z]{3}$/
+      errors.add(:tracking_number, "must be 12 characters, starting with 9 numbers and ending with 3 letters")
     elsif tracking_number_already_exists?
       errors.add(:tracking_number, "must be unique")
     elsif exists_with_different_tracking_number?

--- a/app/views/manifests/new.html.erb
+++ b/app/views/manifests/new.html.erb
@@ -1,13 +1,4 @@
 <div class="usa-width-one-whole">
-
-  <% if @errors %>
-    <div class="validation-errors">
-    <% @errors.each do |error| %>
-      <div class="error"><%= error %></div>
-    <% end %>
-    </div>
-  <% end %>
-
   <h3>Submit new manifest</h3>
 
   <%= simple_form_for :manifest, url: manifests_path, method: :post do |form| %>

--- a/app/views/manifests/new.html.erb
+++ b/app/views/manifests/new.html.erb
@@ -15,7 +15,7 @@
     <%= form.simple_fields_for :generator do |generator| %>
       <%= generator.input :us_epa_id_number, label: 'U.S. EPA ID Number (1)' %>
       <%= generator.input :emergency_response_phone, label: 'Emergency Response Phone (3)' %>
-      <%= generator.input :manifest_tracking_number, label: 'Manifest Tracking Number (4)' %>
+      <%= generator.input :manifest_tracking_number, label: 'Manifest Tracking Number (4)', required: true %>
       <%= generator.input :name, label: 'Name (5)' %>
 
       <h3>Mailing address</h3>

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -20,4 +20,5 @@ SimpleForm.setup do |config|
   config.error_notification_class = 'error_notification'
   config.browser_validations = false
   config.boolean_label_class = 'checkbox'
+  config.required_by_default = false
 end

--- a/spec/features/create_manifest_spec.rb
+++ b/spec/features/create_manifest_spec.rb
@@ -11,6 +11,26 @@ feature 'Create manifest' do
     expect(page).to have_content("Manifest #{manifest_tracking_number} submitted successfully.")
   end
 
+  scenario 'does not fill in tracking number' do
+    visit new_manifest_path
+
+    click_on 'Continue'
+
+    expect(page).to have_content("Tracking number must be present")
+  end
+
+  scenario 'fills in tracking number that does not match validation regex' do
+    manifest_tracking_number = "invalid"
+    visit new_manifest_path
+
+    fill_in 'Manifest Tracking Number (4)', with: manifest_tracking_number
+    click_on 'Continue'
+
+    expect(page).to have_content(
+      "Tracking number must be 12 characters, starting with 9 numbers and ending with 3 letters"
+    )
+  end
+
   scenario 'fills in all fields' do
     manifest_tracking_number = '987654321ABC'
     visit new_manifest_path

--- a/spec/models/manifest_spec.rb
+++ b/spec/models/manifest_spec.rb
@@ -7,6 +7,29 @@ describe Manifest do
 
       expect(manifest).to be_invalid
     end
+
+    it 'validates uniqueness of manifest tracking number' do
+      manifest = create(:manifest)
+      duplicate_manifest = build(
+        :manifest,
+        content: { generator: { manifest_tracking_number: manifest.tracking_number} }
+      )
+
+      expect(duplicate_manifest).to be_invalid
+    end
+
+    it 'does not validate uniqueness of manifest trackig number against itself' do
+      manifest = create(:manifest)
+      manifest.content['generator']['manifest_tracking_number'] = manifest.tracking_number
+
+      expect(manifest).to be_valid
+    end
+
+    it 'validates format of manifest tracking number' do
+      manifest = build(:manifest, content: { generator: { manifest_tracking_number: '123' } })
+
+      expect(manifest).to be_invalid
+    end
   end
 
   describe '#uuid' do
@@ -44,7 +67,7 @@ describe Manifest do
       end
 
       it 'does not allow manifests with duplicate tracking number' do
-        tracking_number = '12345'
+       tracking_number = '987654321ABC'
 
         manifest = create(:manifest, content: { generator: { manifest_tracking_number: tracking_number } })
         expect {

--- a/spec/requests/api/v0/patch_manifest_spec.rb
+++ b/spec/requests/api/v0/patch_manifest_spec.rb
@@ -4,13 +4,14 @@ describe 'PATCH Manifest' do
   describe 'PATCH manifest' do
     context 'finds manifest with id param' do
       it 'updates removes and adds fields to a manifest by uuid' do
+        manifest_tracking_number = '987654321ABC'
         patch_command = [{"op": "replace", "path": "/hello", "value": "people"}, {"op": "add", "path": "/newitem", "value": "beta"},{"op": "remove", "path": "/foo/1"},{"op": "replace", "path": "/nested/something", "value": "ok"}]
         manifest = create(
           :manifest,
           activity_id: 2,
           document_id: 3,
           content: {
-            generator: { manifest_tracking_number: '12345' },
+            generator: { manifest_tracking_number: manifest_tracking_number },
             hello: 'world',
             foo: ['bar', 'baz', 'quux'],
             nested: { something: 'good' }
@@ -28,7 +29,7 @@ describe 'PATCH Manifest' do
           'newitem' => 'beta',
           'foo' => ['bar', 'quux'],
           'nested' => { 'something' => 'ok' },
-          'generator' => { 'manifest_tracking_number' => '12345' }
+          'generator' => { 'manifest_tracking_number' => manifest_tracking_number }
         }
 
         parsed_response = JSON.parse(response.body)
@@ -40,13 +41,14 @@ describe 'PATCH Manifest' do
       end
 
       it 'updates removes and adds fields to a manifest by tracking number' do
+       manifest_tracking_number = '987654321ABC'
         patch_command = [{"op": "replace", "path": "/hello", "value": "people"}, {"op": "add", "path": "/newitem", "value": "beta"},{"op": "remove", "path": "/foo/1"},{"op": "replace", "path": "/nested/something", "value": "ok"}]
         manifest = create(
           :manifest,
           activity_id: 2,
           document_id: 3,
           content: {
-            generator: { manifest_tracking_number: '12345' },
+            generator: { manifest_tracking_number: manifest_tracking_number },
             hello: 'world',
             foo: ['bar', 'baz', 'quux'],
             nested: { something: 'good' }
@@ -64,7 +66,7 @@ describe 'PATCH Manifest' do
           'newitem' => 'beta',
           'foo' => ['bar', 'quux'],
           'nested' => { 'something' => 'ok' },
-          'generator' => { 'manifest_tracking_number' => '12345' }
+          'generator' => { 'manifest_tracking_number' => manifest_tracking_number }
         }
 
         parsed_response = JSON.parse(response.body)


### PR DESCRIPTION
- Formerly, was showing json_schema errors first, which were hard to
  understand

Before:

![screen shot 2016-01-26 at 3 00 57 pm](https://cloud.githubusercontent.com/assets/601515/12598173/89d21726-c43d-11e5-9723-a20fa5e17a37.png)

After:

![screen shot 2016-01-26 at 3 01 06 pm](https://cloud.githubusercontent.com/assets/601515/12598169/86371436-c43d-11e5-84a3-87c589f34c8b.png)
