### PR TITLE
Do not show manifest tracking id form field when signing existing manifest

### DIFF
--- a/app/controllers/manifest_uploads_controller.rb
+++ b/app/controllers/manifest_uploads_controller.rb
@@ -1,9 +1,10 @@
 class ManifestUploadsController < ApplicationController
   def new
+    @manifest = find_or_initialize_manifest
   end
 
   def create
-    manifest = find_or_initialize_manifest
+    manifest = update_manifest(find_or_initialize_manifest)
 
     if manifest.save
       flash[:notice] = "Upload for manifest #{manifest.tracking_number} submitted successfully."
@@ -18,11 +19,17 @@ class ManifestUploadsController < ApplicationController
 
   def find_or_initialize_manifest
     if params[:manifest_id]
-      manifest = Manifest.find_by_uuid_or_tracking_number!(params[:manifest_id])
-      manifest.content[:uploaded_file] = image_details
-      manifest
+      Manifest.find_by_uuid_or_tracking_number!(params[:manifest_id])
     else
-      Manifest.new(content: parsed_upload_params)
+      Manifest.new
+    end
+  end
+
+  def update_manifest(manifest)
+    if params[:manifest_id]
+      manifest.tap { |object| object.content[:uploaded_file] = image_details }
+    else
+      manifest.tap { |object| object.content = parsed_upload_params }
     end
   end
 

--- a/app/views/manifest_uploads/new.html.erb
+++ b/app/views/manifest_uploads/new.html.erb
@@ -4,10 +4,11 @@
 
   <%= simple_form_for :manifest, url: upload_path, method: :post do |form| %>
     <%= form.input :uploaded_file, as: :file %>
-    <%= form.simple_fields_for :generator do |generator| %>
-      <%= generator.input :manifest_tracking_number, label: 'Manifest Tracking Number' %>
+    <% if !@manifest.persisted? %>
+      <%= form.simple_fields_for :generator do |generator| %>
+        <%= generator.input :manifest_tracking_number, label: 'Manifest Tracking Number' %>
+      <% end %>
     <% end %>
     <%= form.submit 'Submit' %>
   <% end %>
-
 </div>

--- a/spec/features/upload_scan_spec.rb
+++ b/spec/features/upload_scan_spec.rb
@@ -19,6 +19,8 @@ feature 'Upload scan', elasticsearch: true do
     fill_in 'Manifest Tracking Number (4)', with: manifest_tracking_number
     click_on 'Continue'
     click_on 'Upload'
+    expect(page).not_to have_field('Manifest Tracking Number')
+
     attach_file('manifest[uploaded_file]', Rails.root + "spec/support/fixtures/epa_form.pdf")
     click_on 'Submit'
 


### PR DESCRIPTION
- When uploading scan after create, confusing to show manifest tracking # field
