### PR TITLE
Update _manifest.json

### DIFF
--- a/app/views/examples/_manifest.json
+++ b/app/views/examples/_manifest.json
@@ -1,5 +1,6 @@
 {
    "generator" : {
+      "manifest_tracking_number" : "987654321ABC",
       "us_epa_id_number" : "ABC712334321",
       "emergency_response_phone" : "888-999-8888",
       "signatory" : {
@@ -25,7 +26,6 @@
          "zip_code" : "71291",
          "city" : "Looptown"
       },
-      "manifest_tracking_number" : "987654321ABC",
       "phone_number" : "800-883-1731"
    },
    "manifest_items" : [


### PR DESCRIPTION
Since this is an example, I moved the one mandatory field (manifest_tracking_number) to the top so that people testing the app can easily find it and edit it.  I thought about changing the value in the example for "manifest_tracking_number" to a note that would not validate, but decided not to. here is an example of that thought:

```
  "manifest_tracking_number" : "ENTER A STRING OF 9 Digits and 3 Character, for example 123456789ABC"
```

Would this be useful or should we leave it as an example.
