### PR TITLE
zero-downtime-push does not preserve env vars from *-venerable rename

### DIFF
--- a/script/deploy
+++ b/script/deploy
@@ -14,4 +14,9 @@ if ! hash autopilot 2>/dev/null; then
   exit 1
 fi
 
-cf zero-downtime-push $1 -f ${1}.manifest.yml
+APPNAME=$1
+
+cf create-app-manifest $APPNAME
+cf zero-downtime-push $APPNAME -f ${APPNAME}_manifest.yml
+cf create-app-manifest ${APPNAME}-worker
+cf zero-downtime-push ${APPNAME}-worker ${APPNAME}-worker_manifest.yml


### PR DESCRIPTION
zero-downtime renames the live instance, then creates a new one. But it fails to copy over the env from the existing live instance. This PR creates a temp manifest and deploys using it, so env is preserved.
