### PR TITLE
Typo fixes + a couple of minor edits

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,12 +23,12 @@
 
 ### Development practices
 
-* Everything that's in the "Current" column in
+* Everything in the "Current" column in
   [Trello](https://trello.com/b/0geMlbgF/epa-emanifest) is fair game.
 * When you start work on a task, move it to "Work In Progress" and self-assign.
 * Create a branch off of master for each feature and open a pull request when
   development on that feature is ready to be reviewed.
-* Once it's ready for review, move the card to "Ready for Review" in Trello
+* Once it's ready for review, move the card to "Ready for Review" in Trello.
 * Assign pull requests you are reviewing to yourself so others know that you are
   reviewing.
 * A pull request must receive a thumbs up from at least one person other than
@@ -46,7 +46,7 @@
 * The merger should also push the updated master branch to production.
 * When a feature is reviewed/merged and pushed to production (our only integration
   server) where the client/product owner can verify, move the card to
-  "pending acceptance"
+  "pending acceptance".
 
 ### One-off Tasks
 
@@ -97,16 +97,14 @@ The `ab` tool has better reporting but cannot handle things like POSTing a uniqu
 
 ## CROMERR Signing
 
-We submit and sign manifest data to another API known as CDX.
+We submit and sign manifest data to another API known as [CDX](https://cdx.epa.gov/).
 
-The signing process generally goes under the pseudo-trade name of CROMERR (or
+The signing process generally goes under the pseudo-trade name of [CROMERR](https://www.epa.gov/cromerr) (or
 CROMERR-compliant), so you’ll hear both terms in regards to the third party API
 we use.
 
-In order to access the development CDX system for CROMERR signing of a manifest,
-one needs a system account set up with rights to sign on behalf of authenticated
-users. The account credentials are available from the e-Manifest development
-team.
+You need a system account set up with rights to sign on behalf of authenticated
+users to access the development CDX system for CROMERR signing of a manifest. The account credentials are available from the e-Manifest development team.
 
 The username and password env variables should be in the `.env` file
 located in the root with the following form:
@@ -114,13 +112,11 @@ located in the root with the following form:
     CDX_USERNAME = "put username here"
     CDX_PASSWORD = "put password here"
 
-In addition to these API keys, you will need the username, password, and
-security question answers in order to sign in via the web UI. These can also be
-obtained via team members.
+In addition to these API keys, you need the username, password, and security question answers in order to sign in via the web UI. These can also be obtained via team members.
 
 The `CDX_LOG` and `CDX_COLOR` environment variables control the verbosity and style of the CDX
 model logging. Currently the `CDX_LOG` variable must be set to `true` when running the rspec test suite,
-and therefor is explicitly set in the `.env.test` file.
+and therefore is explicitly set in the `.env.test` file.
 
 See also the [Authentication and Authorization architecture documentation](doc/authorization.md).
 

--- a/README.md
+++ b/README.md
@@ -6,31 +6,30 @@
 [![Code
 Climate](https://codeclimate.com/github/18F/e-manifest/badges/gpa.svg)](https://codeclimate.com/github/18F/e-manifest)
 
+
 ## Application architecture
 
-This is a Rails application with a Postgres database. The app contains both API
+This is a Rails application with a Postgres database containing both API
 endpoints and web views. The API is a JSON REST API. The web app and the API
 use the same database.
 
-Elasticsearch is used to search for manifest records. Elasticsearch offloads
-read-access from the database and provides full-text search that can be painful
-to apply directly to a database
+We use Elasticsearch to search for manifest records. Elasticsearch offloads
+read-access from the database and provides full-text search capabilities painful
+to apply directly to a database.
 
-Redis is being used for Sidekiq job processing. The Redis + Sidekiq solution
+Redis is used for Sidekiq job processing. The Redis + Sidekiq solution
 offloads the database/Elasticsearch syncing to an async process.
 
 ## Developer onboarding
 
-Here are some tips and resources for getting started on this project. Note that
-not all of these resources are available to people outside of the EPA / 18F for
-security reasons.
+Here are some tips and resources for getting started on this project. Note not all resources are available to people outside of the EPA / 18F for security reasons.
 
 * Join the `#c-epa-emanifest` and `#e-manifest-partners` channels in the 18F
   Slack organization.
 * Ask in Slack for the Vendor Onboarding document for background on the problem space.
 * Read the [project
   brief](https://docs.google.com/document/d/1v_rRaV5euxmBdH8D_Huo37kN3Yu76sNn2TXVJJB4v40/edit).
-* Make sure you've been added to the [Trello
+* Make sure you're added to the [Trello
   board](https://trello.com/b/0geMlbgF/epa-emanifest).
 * Set up the app using the instructions in [CONTRIBUTING.md](CONTRIBUTING.md).
 

--- a/doc/authorization.md
+++ b/doc/authorization.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-[CDX](https://devngn.epacdxnode.net/) provides User authentication and authorization 
+The [CDX development environment](https://devngn.epacdxnode.net/) provides User authentication and authorization 
 services. The e-Manifest application delegates all storage and management to CDX,
 and communicates with the CDX SOAP API via the `CDX::*` model classes.
 For efficiency, the e-Manifest application caches some CDX data locally
@@ -25,6 +25,6 @@ share a single UserSession object.
 Authorization is performed via the [Pundit gem](https://github.com/elabs/pundit).
 CDX User, Organization and Role profile information is cached locally in Postgres
 via the `UserProfileBuilder` and `UserProfileSyncer` classes. Postgres is used
-to persist authorization profiles beyond the short lifespan of a `UserSession`,
-because authorization roles must be included in the Elasticsearch indices, which
+to persist authorization profiles beyond the short lifespan of a `UserSession`
+because authorization roles must be included in the Elasticsearch indices which
 may be re-built asynchronously to any given user session.


### PR DESCRIPTION
Saw a couple of typos in the text. Fixed them and gave the rest of the content a _very_ cursory edit pass.

Added some URLs for references-- when we split the content between pages, not every page wound up with a link to a previously referenced URL.
