### PR TITLE
add Authorization header to swagger ui

### DIFF
--- a/app/views/api-docs/swagger/index.html.erb
+++ b/app/views/api-docs/swagger/index.html.erb
@@ -11,4 +11,10 @@
   <% end %>
 
   <%= render 'swagger_ui/swagger_ui', discovery_url: 'swagger.json' %>
+
+  <% if current_user %>
+    <script type="text/javascript">
+      window.authorizations.add("key", new ApiKeyAuthorization("Authorization", "Bearer <%= user_session.token %>", "header"));
+    </script>
+  <% end %>
 </div>


### PR DESCRIPTION
Swagger UI needs to have Authorization header added to all HTTP requests because Rails session is not available in `/api` endpoints.
