### PR TITLE
User profile page

### DIFF
--- a/app/controllers/auth_controller.rb
+++ b/app/controllers/auth_controller.rb
@@ -30,6 +30,9 @@ class AuthController < ApplicationController
     end
   end
 
+  def profile
+  end
+
   private
 
   def authenticate

--- a/app/models/cdx/profile_request.rb
+++ b/app/models/cdx/profile_request.rb
@@ -24,6 +24,8 @@ class CDX::ProfileRequest < CDX::LoggedRequest
       thing.each do |subthing|
         lower_camelize(subthing)
       end
+    elsif thing.nil?
+      # no-op
     else
       fail "Unsupported object: #{thing.pretty_inspect}"
     end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -12,10 +12,10 @@ class Organization < ActiveRecord::Base
   private
 
   def self.find_from_cdx(cdx_org)
-    find_by(cdx_org_name: cdx_org[:organization_name], cdx_org_id: cdx_org[:organization_id])
+    find_by(cdx_org_name: cdx_org[:organizationName], cdx_org_id: cdx_org[:organizationId])
   end
 
   def self.create_from_cdx(cdx_org)
-    create(cdx_org_name: cdx_org[:organization_name], cdx_org_id: cdx_org[:organization_id])
+    create(cdx_org_name: cdx_org[:organizationName], cdx_org_id: cdx_org[:organizationId])
   end
 end

--- a/app/services/user_authenticator.rb
+++ b/app/services/user_authenticator.rb
@@ -57,12 +57,15 @@ class UserAuthenticator
       nil
     else
       user = User.find_or_create(user_id)
-      UserSession.create(user, cdx_response)
+      session = UserSession.create(user, cdx_response)
+      UserProfileWorker.perform_async(user.id)
+      session
     end
   end
 
   def merge_session(cdx_response)
     @session.user = User.find_or_create(user_id)
+    UserProfileWorker.perform_async(@session.user.id)
     @session.merge_cdx(cdx_response)
   end
 end

--- a/app/services/user_profile_builder.rb
+++ b/app/services/user_profile_builder.rb
@@ -32,7 +32,7 @@ class UserProfileBuilder
 
   def populate_roles(organizations, profile, security_token)
     organizations.each do |org|
-      profile[:organizations][org[:organization_name]] = { org: org, roles: {} }
+      profile[:organizations][org[:organizationName]] = { org: org, roles: {} }
       roles = CDX::UserRoles.new(
         user_id: user.cdx_user_id,
         dataflow: dataflow,
@@ -41,7 +41,7 @@ class UserProfileBuilder
         security_token: security_token
       ).perform
       roles.each do |role|
-        profile[:organizations][org[:organization_name]][:roles][role[:type][:description]] = role
+        profile[:organizations][org[:organizationName]][:roles][role[:type][:description]] = role
       end
     end
   end

--- a/app/services/user_profile_syncer.rb
+++ b/app/services/user_profile_syncer.rb
@@ -50,7 +50,7 @@ class UserProfileSyncer
     org = Organization.from_cdx(cdx_org)
     role = Role.from_cdx(cdx_role)
     user_org_role = UserOrgRole.new(organization: org, role: role)
-    user_org_role.cdx_user_role_id = cdx_role[:user_role_id]
+    user_org_role.cdx_user_role_id = cdx_role[:userRoleId]
     user_org_role.cdx_status = cdx_role[:status][:code]
     user.user_org_roles << user_org_role
   end

--- a/app/views/auth/profile.html.erb
+++ b/app/views/auth/profile.html.erb
@@ -1,0 +1,24 @@
+<div class="usa-width-one-whole">
+
+  <div class="profile">
+    <% if !current_user %>
+      You must <%= link_to("sign in", login_path) %> to view your profile.
+    <% else %>
+      Welcome, <%= user_session.user_name %> (<%= current_user.cdx_user_id %>).
+      <table class="roles">
+        <thead>
+          <tr><th>Organization</th><th>Role</th><th>Status</th></tr>
+        </thead>
+        <tbody>
+          <% current_user.user_org_roles.each do |user_org_role| %>
+          <tr class="user-org-role">
+            <td><%= user_org_role.organization.cdx_org_name %></td>
+            <td><%= user_org_role.role.cdx_role_name %></td>
+            <td><%= user_org_role.cdx_status %></td>
+          </tr>
+        </tbody>
+      </table>
+    <% end %>
+ <% end %>
+ </div>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,7 +29,8 @@
         <%= link_to 'Industry', new_submission_path %>
         <%= link_to 'API', '/api-documentation/' %>
         <% if current_user %>
-        <%= link_to "Sign Out #{user_session.user_name}", logout_path %>
+        <%= link_to "Sign Out", logout_path %>
+        <%= link_to "#{user_session.user_name}", profile_path %>
         <% else %>
         <%= link_to "Sign in", login_path %>
         <% end %>

--- a/app/workers/user_profile_worker.rb
+++ b/app/workers/user_profile_worker.rb
@@ -1,0 +1,13 @@
+class UserProfileWorker
+  include Sidekiq::Worker
+  sidekiq_options queue: 'default', retry: true, backtrace: true
+
+  def perform(user_id, dataflow = ENV['CDX_DEFAULT_DATAFLOW'])
+    user = User.find(user_id)
+    builder = UserProfileBuilder.new(user, dataflow)
+    profile = builder.run
+    puts profile.pretty_inspect
+    syncer = UserProfileSyncer.new(user, profile)
+    syncer.run
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
   get 'login', to: 'auth#new'
   post 'login', to: 'auth#login'
   get 'logout', to: 'auth#logout'
+  get 'profile', to: 'auth#profile'
 
   get 'api-examples', to: 'api_documentation#examples'
   get 'api-diagnostics', to: 'api_documentation#diagnostics'

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -9,7 +9,7 @@ describe Organization do
 
   describe '#from_cdx' do
     it 'parsed CDX response' do
-      cdx_org = { organization_name: 'foo', organization_id: '123' }
+      cdx_org = { organizationName: 'foo', organizationId: '123' }
       organization = Organization.from_cdx(cdx_org)
       expect(organization).to be_a(Organization)
       expect(organization.cdx_org_name).to eq('foo')

--- a/spec/requests/auth_spec.rb
+++ b/spec/requests/auth_spec.rb
@@ -29,6 +29,16 @@ describe 'Auth' do
     end
   end
 
+  describe 'profile' do
+    it 'shows orgs + roles' do
+      user_session = mock_authenticated_session
+      user_org_role = create(:user_org_role, user: user_session.user, cdx_status: 'foo')
+      get "/profile"
+      expect(response.body).to include('foo')
+      expect(response.body).to include(user_session.user_name)
+    end
+  end
+
   describe 'logout' do
     it 'clears session' do
       user_session = mock_user_authenticator_pass

--- a/spec/services/user_profile_builder_spec.rb
+++ b/spec/services/user_profile_builder_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+describe UserProfileBuilder do
+  it 'builds a profile' do
+    mock_cdx_profiles
+    user = create(:user, cdx_user_id: 'some_user')
+    builder = UserProfileBuilder.new(user, 'foo')
+    expect(builder.run).to eq(mock_cdx_user_profile)
+  end
+end

--- a/spec/services/user_profile_syncer_spec.rb
+++ b/spec/services/user_profile_syncer_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+describe UserProfileSyncer do
+  it 'builds orgs + roles from a profile' do
+    user = create(:user, cdx_user_id: 'some_user')
+    syncer = UserProfileSyncer.new(user, mock_cdx_user_profile)
+    syncer.run
+    expect(user.organizations.map(&:cdx_org_name)).to eq(['EPA 2'])
+    expect(user.roles.map(&:cdx_role_name)).to eq(['TSDF'])
+  end
+end

--- a/spec/support/user_authenticator_helper.rb
+++ b/spec/support/user_authenticator_helper.rb
@@ -25,4 +25,45 @@ module UserAuthenticatorHelper
     allow_any_instance_of(UserAuthenticator).to receive(:authorize_signature).and_return(nil)
     allow_any_instance_of(UserAuthenticator).to receive(:error_message).and_return('Bad user_id or password')
   end
+
+  def mock_cdx_user_profile
+    {
+      organizations: {
+        "EPA 2" => {
+          org: {
+            organizationId: "15404",
+            organizationName: "EPA 2",
+            primaryOrg: true,
+            userOrganizationId: "86328",
+          },
+          roles: {
+            "TSDF" => {
+              dataflow: "eManifest",
+              status: {
+                code: "Active",
+                description: "Active"
+              },
+              type: {
+                code: "112090",
+                description: "TSDF",
+                status: "Active"
+              },
+              userRoleId: "87638"
+            }
+          }
+        }
+      },
+      user: {
+        firstName: "Test",
+        lastName: "Tester",
+        status: "Valid",
+        userId: "some_user",
+      }
+    }
+  end
+
+  def mock_cdx_profiles
+    allow(UserProfileWorker).to receive(:perform_async).and_return(true)
+    allow_any_instance_of(UserProfileBuilder).to receive(:run).and_return(mock_cdx_user_profile)
+  end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/ep2wQ2cl and https://trello.com/c/WencMlIE

This adds a `/profile` endpoint to show a signed-in user what the app thinks their orgs+roles are.

Also includes fix for regression in user profile sync (attribute names case), and a background worker to keep CDX and this app in sync.
