### PR TITLE
Add Canadian provinces and Mexican states to search

### DIFF
--- a/app/helpers/states_helper.rb
+++ b/app/helpers/states_helper.rb
@@ -55,4 +55,56 @@ module StatesHelper
       ['Wyoming', 'WY']
     ]
   end
+
+  def canadian_provinces
+    [
+      ['Ontario', 'ON'],
+      ['Quebec', 'QC'],
+      ['Nova Scotia', 'NS'],
+      ['New Brunswick', 'NB'],
+      ['Manitoba', 'MB'],
+      ['British Columbia', 'BC'],
+      ['Prince Edward Island', 'PE'],
+      ['Saskatchewan', 'SK'],
+      ['Alberta', 'AB'],
+      ['Newfoundland and Labrador', 'NL']
+    ]
+  end
+
+  def mexican_states
+    [
+      ['Aguascalientes', 'MX - AG'],
+      ['Baja California', 'MX - BN'],
+      ['Baja California Sur', 'MX - BS'],
+      ['Campeche', 'MX - CM'],
+      ['Chiapas', 'MX - CP'],
+      ['Chihauhua', 'MX - CH'],
+      ['Coahuila', 'MX - CA'],
+      ['Colima', 'MX - CL'],
+      ['Federal District', 'MX - DF'],
+      ['Durango', 'MX - DU'],
+      ['Guanajuato', 'MX - GT'],
+      ['Guerrero', 'MX - GR'],
+      ['Hidalgo', 'MX - HI'],
+      ['Jalisco', 'MX - JA'],
+      ['México', 'MX - MX'],
+      ['Michoacán', 'MX - MC'],
+      ['Morelos', 'MX - MR'],
+      ['Nayarit', 'MX - NA'],
+      ['Nuevo León', 'MX - NL'],
+      ['Oaxaca', 'MX - OA'],
+      ['Puebla', 'MX - PU'],
+      ['Querétaro', 'MX - QE'],
+      ['Quintana Roo', 'MX - QR'],
+      ['San Luis Potosí', 'MX - SL'],
+      ['Sinaloa', 'MX - SI'],
+      ['Sonora', 'MX - SO'],
+      ['Tabasco', 'MX - TB'],
+      ['Tamaulipas', 'MX - TM'],
+      ['Tlaxcala', 'MX - TL'],
+      ['Veracruz', 'MX - VE'],
+      ['Yucatán', 'MX - YU'],
+      ['Zacatecas', 'MX - ZA']
+    ]
+  end
 end

--- a/app/views/manifests/index.html.erb
+++ b/app/views/manifests/index.html.erb
@@ -53,18 +53,42 @@
         <label for="origin_state">Generator state</label>
         <select name="aq[content.generator.mailing_address.state]" id="origin_state" class="usa-input-grid-tiny tiny-input">
           <option value="">--</option>
-          <% us_states.each do |state| %>
-           <option value=<%=state[1]%>><%=state[1]%></option>
-          <% end %>
+          <optgroup label="United States">
+            <% us_states.each do |state| %>
+             <option value=<%=state[1]%>><%=state[1]%></option>
+            <% end %>
+          </optgroup>
+          <optgroup label="Canadian Provinces">
+            <% canadian_provinces.each do |province| %>
+             <option value=<%=province[1]%>><%=province[1]%></option>
+            <% end %>
+          </optgroup>
+          <optgroup label="Mexican States">
+            <% mexican_states.each do |state| %>
+             <option value=<%=state[1]%>><%=state[1]%></option>
+            <% end %>
+          </optgroup>
         </select>
       </div>
       <div class="usa-width-one-half">
         <label for="disposal_state">Disposal facility state</label>
         <select name="aq[content.designated_facility.address.state]" id="disposal_state" class="tiny-input">
           <option value="">--</option>
-          <% us_states.each do |state| %>
-           <option value=<%=state[1]%>><%=state[1]%></option>
-          <% end %>
+          <optgroup label="United States">
+            <% us_states.each do |state| %>
+             <option value=<%=state[1]%>><%=state[1]%></option>
+            <% end %>
+          </optgroup>
+          <optgroup label="Canadian Provinces">
+            <% canadian_provinces.each do |province| %>
+             <option value=<%=province[1]%>><%=province[1]%></option>
+            <% end %>
+          </optgroup>
+          <optgroup label="Mexican States">
+            <% mexican_states.each do |state| %>
+             <option value=<%=state[1]%>><%=state[1]%></option>
+            <% end %>
+          </optgroup>
         </select>
       </div>
     </div>


### PR DESCRIPTION
To close out https://trello.com/c/El5kKAkI/312-finish-search-filters-date-state-province-additional

Adds Canadian provinces and Mexican states to search filters. I used Wikipedia to get the postal codes, but not sure that they match up with the data that will be in the database. Can @brandocalrissian or @scottdchristian confirm that these are the proper abbreviations for both countries?
