### PR TITLE
Do not check in the manifest files we generate for cf.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,7 @@
 /tags
 /tmp/*
 test_cdx_config.yml
+e-manifest-dev-worker_manifest.yml
+e-manifest-dev_manifest.yml
+e-manifest-worker_manifest.yml
+e-manifest_manifest.yml


### PR DESCRIPTION
Avoid accidentally getting in the way of our toolchain.
