### PR TITLE
fix CDX signature manifest payload

### DIFF
--- a/app/models/cdx/sign.rb
+++ b/app/models/cdx/sign.rb
@@ -18,7 +18,7 @@ class CDX::Sign < CDX::LoggedRequest
     {
       Name: "e-manifest #{opts[:id]}",
       Format: "BIN",
-      Content: opts[:manifest]
+      Content: Base64.encode64(opts[:manifest])
     }
   end
 

--- a/app/views/manifests/show.html.erb
+++ b/app/views/manifests/show.html.erb
@@ -88,6 +88,9 @@
 </div>
 
 <div class="usa-width-one-third">
+  <div class="actions">
+    <%= link_to 'Sign this manifest', new_manifest_sign_or_upload_path(@manifest.uuid) %>
+  </div>
   <div class="callout">
     <dl>
       <dt>Manifest #</dt>

--- a/spec/models/cdx_spec.rb
+++ b/spec/models/cdx_spec.rb
@@ -131,7 +131,7 @@ describe "CDX" do
           signatureDocument: {
             Name: 'e-manifest id',
             Format: 'BIN',
-            Content: 'content'
+            Content: Base64.encode64('content')
           }
         }
       })


### PR DESCRIPTION
The CDX API requires the manifest content be Base64 encoded.
