### PR TITLE
Update application.html.erb

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta charset="utf-8" />
   <meta name="ROBOTS" content="NOODP" />
   <meta name="viewport" content="initial-scale=1" />


### PR DESCRIPTION
EPA's desktop forces all epa.gov pages to render in ie7.  Adding this tag to override that, so e-manifest renders properly.  Good news next week I get my EPA issued computer updated so I can test locally and download Ruby, Postgres, and the rest of the contributing docs
