### PR TITLE
add user+timestamp to uploaded manifest content, display it

### DIFF
--- a/app/controllers/manifest_uploads_controller.rb
+++ b/app/controllers/manifest_uploads_controller.rb
@@ -68,6 +68,8 @@ class ManifestUploadsController < ApplicationController
 
   def image_details
     {
+      uploaded_at: Time.current,
+      uploaded_by: current_user.id,
       file_name: upload.try(:original_filename),
       content: encoded_file,
       content_type: upload.try(:content_type),

--- a/app/helpers/manifest_helper.rb
+++ b/app/helpers/manifest_helper.rb
@@ -7,6 +7,24 @@ module ManifestHelper
     end
   end
 
+  def file_uploaded_at(manifest)
+    if manifest.content['uploaded_file']['uploaded_at']
+      datetime = Time.parse(manifest.content['uploaded_file']['uploaded_at'])
+      datetime.strftime('%F %T UTC')
+    else
+      "unknown"
+    end
+  end
+
+  def file_uploaded_by(manifest)
+    if manifest.content['uploaded_file']['uploaded_by']
+      user = User.find( manifest.content['uploaded_file']['uploaded_by'])
+      user ? user.cdx_user_id : "unknown"
+    else
+      "unknown"
+    end
+  end
+
   def container_types
     [
       ["BA (Burlap, cloth, paper or plastic bags)", "BA"],

--- a/app/views/manifests/show.html.erb
+++ b/app/views/manifests/show.html.erb
@@ -104,5 +104,10 @@
     </dl>
 
     <%= file_upload_button(@manifest) %>
+    <% if @manifest.content['uploaded_file'] %>
+    Uploaded <strong><%= file_uploaded_at(@manifest) %></strong>
+    <br />
+    by <strong><%= file_uploaded_by(@manifest) %></strong>
+    <% end %>
   </div>
 </div>

--- a/spec/features/view_manifest_spec.rb
+++ b/spec/features/view_manifest_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 feature 'View manifest' do
   scenario 'manifest has a file uploaded during creation', elasticsearch: true do
-    mock_authenticated_session
+    session = mock_authenticated_session
     manifest_tracking_number = '987654321abc'
     visit new_manifest_upload_path
     fill_in 'Manifest Tracking Number', with: manifest_tracking_number
@@ -12,6 +12,7 @@ feature 'View manifest' do
     visit manifest_path(manifest_tracking_number)
 
     expect(page).to have_content('Download Scanned Image')
+    expect(page).to have_content(/Uploaded \d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d UTC by #{session.user.cdx_user_id}/)
   end
 
   scenario 'manifest has file uploaded after creation', elasticsearch: true do


### PR DESCRIPTION
trello: https://trello.com/c/01xAg8o2/289-3-as-the-epa-i-can-store-scans-of-manifests-in-a-database-along-with-some-metadata-company-who-signed-it-timestamp-what-else

![screen shot 2016-03-28 at 1 19 59 pm](https://cloud.githubusercontent.com/assets/1205061/14085845/cdbb9310-f4e7-11e5-9baf-d95195cc0fe2.png)
